### PR TITLE
PySide6: guard de errores global + fixes de concurrencia en GitView (evita cierres abruptos)

### DIFF
--- a/buildtool/app.py
+++ b/buildtool/app.py
@@ -1,39 +1,42 @@
+# buildtool/app.py
 from __future__ import annotations
-import sys, os, traceback, atexit, io, faulthandler
-from .core import errguard
+import sys, os, traceback, atexit
 
+from .core.errguard import install_error_guard, on_about_to_quit_flush, log
+from .core.qt_silence import setup_qt_logging  # ← filtra niveles de Qt (no instala handler)
+
+# Bitácora adicional (opcional) en el HOME del usuario
 CRASH_LOG = os.path.join(os.path.expanduser("~"), "forgebuild_crash.log")
 
 def _open_crash_file():
     try:
-        # Abre en append para acumular runs
         return open(CRASH_LOG, "a", encoding="utf-8")
     except Exception:
         return None
 
 def main():
     print("== ForgeBuild app: entering main() ==")
-    errguard.install(verbose=True)
-    errguard.log(f"== app.main: python={sys.version} exe={sys.executable} cwd={os.getcwd()} ==")
 
-    # === Ambiente Qt para evitar aborts por warnings y mejorar trazas ===
-    os.environ.setdefault("QT_FATAL_WARNINGS", "0")         # no abort por warnings
+    # 1) Instalar guard de errores LO MÁS TEMPRANO POSIBLE (hooks + logger + faulthandler + handler Qt)
+    install_error_guard(app_name="buildtool", verbose=True)
+
+    # 2) Reglas de logging de Qt (solo filtra niveles; NO instala handler)
+    #    Opciones: "warn" (por defecto), "error", "off"
+    setup_qt_logging(level="warn")
+
+    # 3) Variables de entorno Qt útiles (no fuerzan abort por warnings)
+    os.environ.setdefault("QT_FATAL_WARNINGS", "0")
     os.environ.setdefault("QT_ASSUME_STDERR_HAS_CONSOLE", "1")
-    os.environ.setdefault("QT_LOGGING_RULES", "*.debug=true;qt.qpa.*=true")
-    # Si has visto problemas de GPU/OpenGL, prueba:
+    # Si necesitas más verbosidad de Qt durante diagnóstico, descomenta:
+    # os.environ.setdefault("QT_LOGGING_RULES", "*.debug=true;qt.qpa.*=true")
+    # Si hay broncas de GPU/OpenGL en algunas máquinas:
     # os.environ.setdefault("QT_OPENGL", "software")
 
-    # === Crash file & faulthandler ===
+    # 4) Bitácora adicional (opcional)
     crash_fh = _open_crash_file()
     if crash_fh:
         crash_fh.write("\n===== ForgeBuild start =====\n")
         crash_fh.flush()
-        try:
-            faulthandler.enable(file=crash_fh)
-        except Exception:
-            pass
-        # Si cuelga, volcar trazas a los X segundos
-        # faulthandler.dump_traceback_later(30.0, repeat=True, file=crash_fh)
 
         @atexit.register
         def _atexit_marker():
@@ -43,18 +46,21 @@ def main():
             except Exception:
                 pass
 
+    # 5) Crear QApplication DESPUÉS de instalar errguard y configurar reglas Qt
     try:
         from PySide6.QtWidgets import QApplication
-        from PySide6.QtCore import qInstallMessageHandler, QtMsgType
     except Exception as e:
-        errguard.log(f"!! cannot import PySide6: {e}")
+        log(f"!! cannot import PySide6: {e}")
         raise
 
-    # 1) Excepciones no atrapadas del hilo principal
+    app = QApplication.instance() or QApplication(sys.argv)
+    log("== app.main: QApplication ready ==")
+
+    # (Opcional) Volcado extra en crash_fh para uncaught del main
     def _sys_excepthook(exctype, value, tb):
         msg = "[UNCAUGHT] " + "".join(traceback.format_exception(exctype, value, tb))
         try:
-            errguard.log(msg)
+            log(msg)
         except Exception:
             pass
         if crash_fh:
@@ -63,86 +69,60 @@ def main():
                 crash_fh.flush()
             except Exception:
                 pass
-        # No sys.exit aquí
+        # No hacer sys.exit(); errguard ya evita cierre abrupto
 
     sys.excepthook = _sys_excepthook
 
-    # 2) Excepciones “no alzables” (callbacks de GC, etc.)
-    def _unraisable_hook(unraisable):
-        line = f"[UNRAISABLE] {unraisable.exc_value!r} in {unraisable.object!r}"
-        try:
-            errguard.log(line)
-        except Exception:
-            pass
-        if crash_fh:
+    if hasattr(sys, "unraisablehook"):
+        def _unraisable_hook(unraisable):
+            line = f"[UNRAISABLE] {unraisable.exc_value!r} in {unraisable.object!r}"
             try:
-                crash_fh.write(line + "\n")
-                crash_fh.flush()
+                log(line)
             except Exception:
                 pass
-
-    if hasattr(sys, "unraisablehook"):
+            if crash_fh:
+                try:
+                    crash_fh.write(line + "\n")
+                    crash_fh.flush()
+                except Exception:
+                    pass
         sys.unraisablehook = _unraisable_hook
 
-    # 3) Mensajes de Qt a log y a archivo
-    def _qt_msg_handler(mode, ctx, msg):
-        level = {
-            QtMsgType.QtDebugMsg:    "DBG",
-            QtMsgType.QtInfoMsg:     "INF",
-            QtMsgType.QtWarningMsg:  "WRN",
-            QtMsgType.QtCriticalMsg: "CRT",
-            QtMsgType.QtFatalMsg:    "FTL",
-        }.get(mode, "UNK")
-        line = f"[Qt/{level}] {msg}"
-        try:
-            errguard.log(line)
-        except Exception:
-            print(line)
-        if crash_fh:
-            try:
-                crash_fh.write(line + "\n")
-                crash_fh.flush()
-            except Exception:
-                pass
-        # Nota: si es FATAL, Qt puede abortar; al menos queda trazado
-
-    qInstallMessageHandler(_qt_msg_handler)
-
-    app = QApplication.instance() or QApplication(sys.argv)
-    errguard.log("== app.main: QApplication ready ==")
-
+    # 6) Crear y mostrar la ventana principal
     from .main_window import MainWindow
-    errguard.log("== app.main: importing MainWindow ok ==")
+    log("== app.main: importing MainWindow ok ==")
     w = MainWindow()
-    errguard.log("== app.main: MainWindow() constructed ==")
+    log("== app.main: MainWindow() constructed ==")
+    w.show()
+    log("== app.main: MainWindow shown, entering event loop ==")
 
+    # 7) Conectar flush de logs al salir
     try:
-        app.aboutToQuit.connect(lambda: errguard.log("== app.main: aboutToQuit =="))
+        app.aboutToQuit.connect(lambda: log("== app.main: aboutToQuit =="))
+        app.aboutToQuit.connect(on_about_to_quit_flush)
     except Exception:
         pass
 
-    w.show()
-    errguard.log("== app.main: MainWindow shown, entering event loop ==")
-
-    # IMPORTANTE: asegura que pares hilos si algo pide cerrar
+    # 8) Ejecutar loop y cierre ordenado (apaga hilos si usas TRACKER)
     rc = 0
     try:
         rc = app.exec()
     finally:
-        # Cierre forzado de hilos como última línea de defensa
         try:
             from .core.thread_tracker import TRACKER
             TRACKER.stop_all(timeout_ms=7000)
         except Exception:
             pass
 
-        errguard.log(f"== app.main: event loop finished rc={rc} ==")
+        log(f"== app.main: event loop finished rc={rc} ==")
         if crash_fh:
             try:
-                crash_fh.write(f"=====No es repo Gi ForgeBuild loop exit rc={rc} =====\n")
+                crash_fh.write(f"===== ForgeBuild loop exit rc={rc} =====\n")
                 crash_fh.flush()
             except Exception:
                 pass
+
+        on_about_to_quit_flush()
 
     sys.exit(rc)
 

--- a/buildtool/core/errguard.py
+++ b/buildtool/core/errguard.py
@@ -1,171 +1,283 @@
+# buildtool/core/errguard.py
 from __future__ import annotations
-import sys, os, threading, traceback, io
-from pathlib import Path
+
+import asyncio
+import faulthandler
+import io
+import logging
+import os
+import platform
+import sys
+import threading
+import traceback
 from datetime import datetime
+from logging.handlers import RotatingFileHandler
+from typing import Optional, Callable
 
-# ---- helper paths ----
-def _log_dirs():
-    dirs = []
-    try:
-        dirs.append(Path.cwd() / ".forgebuild")
-    except Exception:
-        pass
-    try:
-        if os.name == "nt":
-            la = os.environ.get("LOCALAPPDATA") or os.environ.get("APPDATA")
-            if la:
-                dirs.append(Path(la) / "ForgeBuild")
-    except Exception:
-        pass
-    try:
-        dirs.append(Path.home() / "ForgeBuildLogs")
-    except Exception:
-        pass
-    # de-dup
-    out, seen = [], set()
-    for d in dirs:
-        try:
-            key = str(d.resolve())
-        except Exception:
-            key = str(d)
-        if key not in seen:
-            seen.add(key); out.append(d)
-    return out
+# ----------- Qt opcional -----------
+try:
+    from PySide6.QtCore import qInstallMessageHandler, QtMsgType, QMessageLogContext, qVersion
+    from PySide6.QtWidgets import QApplication, QMessageBox
+    _HAS_QT = True
+except Exception:
+    _HAS_QT = False
+    # Shims para tipado
+    QtMsgType = None
+    QMessageLogContext = None
 
-def _ensure_dirs(ds):
-    ok = []
-    for d in ds:
+# ----------- estado global -----------
+_APP_NAME = "buildtool"
+_LOGGER: Optional[logging.Logger] = None
+_FAULT_FILE: Optional[io.TextIOBase] = None
+_INSTALLED = False  # idempotencia
+_SHOW_DIALOGS = True
+
+# ----------- utilidades -----------
+def _default_logs_dir(app_name: str) -> str:
+    # Respeta repo/local primero
+    for path in (
+        os.path.join(os.getcwd(), ".forgebuild", "logs"),
+        os.path.join(os.getcwd(), "logs"),
+    ):
         try:
-            d.mkdir(parents=True, exist_ok=True)
-            ok.append(d)
+            os.makedirs(path, exist_ok=True)
+            return path
         except Exception:
             pass
-    return ok
+    # Último recurso: temp
+    import tempfile
+    path = os.path.join(tempfile.gettempdir(), f"{app_name}_logs")
+    os.makedirs(path, exist_ok=True)
+    return path
 
-def _open_files(ds):
-    files = []
-    for d in ds:
+def _fmt_env() -> str:
+    parts = [
+        f"Python: {sys.version.split()[0]}",
+        f"Platform: {platform.platform()}",
+        f"Exe: {sys.executable}",
+        f"PID: {os.getpid()}",
+        f"Time: {datetime.now().isoformat(timespec='seconds')}",
+        f"WD: {os.getcwd()}",
+    ]
+    if _HAS_QT:
         try:
-            f = (d / "app.log").open("a", encoding="utf-8", buffering=1, newline="\n")
-            files.append(f)
+            parts.append(f"Qt: {qVersion()}")
         except Exception:
             pass
-    return files
+    return " | ".join(parts)
 
-_files = []
+def _build_logger(app_name: str, logs_dir: Optional[str], verbose: bool) -> logging.Logger:
+    global _LOGGER
+    logs_dir = logs_dir or _default_logs_dir(app_name)
+    log_path = os.path.join(logs_dir, f"{app_name}.log")
 
-def _write_all(text: str) -> None:
-    for f in list(_files):
-        try:
-            f.write(text)
-        except Exception:
-            pass
+    logger = logging.getLogger(app_name)
+    logger.setLevel(logging.DEBUG)
 
-def _ts() -> str:
-    return datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    # Evita duplicar handlers si reinstalan
+    if not any(isinstance(h, RotatingFileHandler) and getattr(h, "_fb_path", None) == log_path
+               for h in logger.handlers):
+        fh = RotatingFileHandler(log_path, maxBytes=2_000_000, backupCount=5, encoding="utf-8")
+        fh._fb_path = log_path  # marker
+        fmt = logging.Formatter(
+            "%(asctime)s [%(levelname)s] %(threadName)s %(name)s:%(lineno)d - %(message)s",
+            datefmt="%Y-%m-%d %H:%M:%S",
+        )
+        fh.setFormatter(fmt)
+        logger.addHandler(fh)
 
-class _Tee(io.TextIOBase):
-    def __init__(self, real):
-        self._real = real
-    def write(self, s):
-        try:
-            _write_all(s)
-        except Exception:
-            pass
-        try:
-            return self._real.write(s)
-        except Exception:
-            return 0
-    def flush(self):
-        try:
-            for f in _files:
-                try:
-                    f.flush()
-                except Exception:
-                    pass
-        except Exception:
-            pass
-        try:
-            return self._real.flush()
-        except Exception:
-            return None
+    # Stream a stderr (visible en dev)
+    if not any(isinstance(h, logging.StreamHandler) and getattr(h, "_fb_stderr", False)
+               for h in logger.handlers):
+        sh = logging.StreamHandler(sys.stderr)
+        sh._fb_stderr = True
+        fmt = logging.Formatter(
+            "%(asctime)s [%(levelname)s] %(threadName)s %(name)s:%(lineno)d - %(message)s",
+            datefmt="%Y-%m-%d %H:%M:%S",
+        )
+        sh.setFormatter(fmt)
+        sh.setLevel(logging.DEBUG if verbose else logging.INFO)
+        logger.addHandler(sh)
 
-def log(msg: str) -> None:
-    line = f"[{_ts()}] {msg}\n"
-    _write_all(line)
-    try:
-        sys.__stdout__.write(line)
-        sys.__stdout__.flush()
-    except Exception:
-        pass
+    logger.debug("Logger listo en %s", log_path)
+    return logger
 
-def _exc_to_text(exctype, value, tb) -> str:
-    return "".join(traceback.format_exception(exctype, value, tb))
-
-def _install_qt_handler() -> None:
-    try:
-        from PySide6.QtCore import qInstallMessageHandler
-    except Exception:
+def _maybe_show_dialog(title: str, message: str) -> None:
+    if not _SHOW_DIALOGS or not _HAS_QT:
         return
-    def handler(msg_type, context, message):
-        # 0 Debug, 1 Warning, 2 Critical, 3 Fatal, 4 Info
-        level = {0:"Debug",1:"Warning",2:"Critical",3:"Fatal",4:"Info"}.get(int(msg_type), str(msg_type))
-        loc = getattr(context, "file", None)
-        line = getattr(context, "line", None)
-        prefix = f"[Qt/{level}]"
-        if loc and line:
-            prefix += f" {loc}:{line}"
-        log(f"{prefix} {message}")
     try:
-        qInstallMessageHandler(handler)
+        app = QApplication.instance()
+        if app is None:
+            return
+        def _show():
+            mb = QMessageBox()
+            mb.setIcon(QMessageBox.Critical)
+            mb.setWindowTitle(title)
+            mb.setText(message)
+            mb.setStandardButtons(QMessageBox.Ok)
+            mb.exec()
+        if threading.current_thread() is threading.main_thread():
+            _show()
+        else:
+            from PySide6.QtCore import QTimer
+            QTimer.singleShot(0, _show)
     except Exception:
         pass
 
-_installed = False
+# ----------- handlers de error -----------
+def _sys_excepthook(exc_type, exc, tb) -> None:
+    msg = "".join(traceback.format_exception(exc_type, exc, tb))
+    if _LOGGER:
+        _LOGGER.critical("Excepción NO capturada\nENV: %s\n%s", _fmt_env(), msg)
+    _maybe_show_dialog("Error crítico", "Ocurrió un error inesperado. Revisa el log para detalles.")
 
-def install(verbose: bool=False) -> None:
-    global _installed, _files
-    if _installed:
+def _thread_excepthook(args: threading.ExceptHookArgs) -> None:
+    try:
+        msg = "".join(traceback.format_exception(args.exc_type, args.exc_value, args.exc_traceback))
+        if _LOGGER:
+            _LOGGER.critical("Excepción en hilo '%s'\n%s", args.thread.name, msg)
+        _maybe_show_dialog("Error en hilo", f"Un hilo falló ({args.thread.name}). Revisa el log.")
+    except Exception:
+        pass
+
+def _asyncio_handler(loop: asyncio.AbstractEventLoop, context: dict) -> None:
+    try:
+        exc = context.get("exception")
+        if exc:
+            tb = "".join(traceback.format_exception(type(exc), exc, exc.__traceback__))
+        else:
+            tb = str(context)
+        if _LOGGER:
+            _LOGGER.error("Excepción en asyncio loop:\n%s", tb)
+    except Exception:
+        pass
+
+def _unraisable_hook(unraisable) -> None:
+    try:
+        line = f"[UNRAISABLE] {unraisable.exc_value!r} in {unraisable.object!r}"
+        if _LOGGER:
+            _LOGGER.error(line)
+    except Exception:
+        pass
+
+def _qt_message_handler(mode: int, context: "QMessageLogContext", message: str) -> None:
+    """
+    Handler único de Qt. Respeta el filtrado que ya definió qt_silence vía
+    QT_LOGGING_RULES / QLoggingCategory; aquí solo registramos lo que Qt emita.
+    """
+    if not _LOGGER:
         return
-    # Qt debug env
-    os.environ.setdefault("QT_DEBUG_PLUGINS", "1")
-    os.environ.setdefault("QT_LOGGING_RULES", "*.debug=true;qt.qpa.*=true")
-    # log sinks
-    dirs = _ensure_dirs(_log_dirs())
-    _files = _open_files(dirs)
-    log("== errguard.install: sinks ready ==")
-    # tee stdout/stderr
+    # Nivel
+    lvl = {
+        QtMsgType.QtDebugMsg: logging.DEBUG,
+        QtMsgType.QtInfoMsg: logging.INFO,
+        QtMsgType.QtWarningMsg: logging.WARNING,
+        QtMsgType.QtCriticalMsg: logging.ERROR,
+        QtMsgType.QtFatalMsg: logging.CRITICAL,
+    }.get(mode, logging.INFO)
+
+    # Contexto (puede venir vacío)
     try:
-        sys.stdout = _Tee(sys.__stdout__ if hasattr(sys, "__stdout__") and sys.__stdout__ else sys.stdout)
-        sys.stderr = _Tee(sys.__stderr__ if hasattr(sys, "__stderr__") and sys.__stderr__ else sys.stderr)
+        file = getattr(context, "file", "") or ""
+        line = getattr(context, "line", 0) or 0
+        func = getattr(context, "function", "") or ""
+        cat  = getattr(context, "category", "") or ""
+        _LOGGER.log(lvl, "Qt: %s [%s:%s %s] {%s}", message, file, line, func, cat)
     except Exception:
-        pass
-    # excepthooks
-    def _hook(exctype, value, tb):
-        log("== Unhandled exception ==\n" + _exc_to_text(exctype, value, tb))
-    sys.excepthook = _hook
-    if hasattr(threading, "excepthook"):
-        def _thook(args):
+        _LOGGER.log(lvl, "Qt: %s", message)
+
+# ----------- API pública -----------
+def install_error_guard(
+    app_name: str = "buildtool",
+    logs_dir: Optional[str] = None,
+    verbose: bool = False,
+    show_dialogs: bool = True,
+) -> logging.Logger:
+    """
+    Instala TODOS los ganchos de error y devuelve el logger configurado.
+    Idempotente: puedes llamarlo varias veces sin efectos adversos.
+    """
+    global _INSTALLED, _LOGGER, _APP_NAME, _SHOW_DIALOGS, _FAULT_FILE
+    _APP_NAME = app_name
+    _SHOW_DIALOGS = bool(show_dialogs)
+
+    if _LOGGER is None:
+        _LOGGER = _build_logger(app_name, logs_dir, verbose)
+
+    if not _INSTALLED:
+        # Python
+        sys.excepthook = _sys_excepthook
+        if hasattr(threading, "excepthook"):
+            threading.excepthook = _thread_excepthook  # type: ignore[attr-defined]
+        if hasattr(sys, "unraisablehook"):
+            sys.unraisablehook = _unraisable_hook  # type: ignore[attr-defined]
+
+        # asyncio
+        try:
+            loop = asyncio.get_event_loop()
+            if loop and loop.is_running():
+                loop.set_exception_handler(_asyncio_handler)
+            # Si no está corriendo, muchos frameworks crean loop luego;
+            # en ese caso, puedes volver a setear handler donde crees el loop.
+        except Exception:
+            pass
+
+        # faulthandler (archivo separado)
+        try:
+            fault_path = os.path.join(_default_logs_dir(app_name), f"{app_name}_faults.log")
+            _FAULT_FILE = open(fault_path, "a", encoding="utf-8")
+            faulthandler.enable(file=_FAULT_FILE, all_threads=True)
+            _LOGGER.debug("faulthandler habilitado en: %s", fault_path)
+        except Exception as e:
+            _LOGGER.warning("No se pudo habilitar faulthandler: %s", e)
+
+        # Qt: solo instalamos nuestro handler (qt_silence ya filtró reglas)
+        if _HAS_QT:
             try:
-                txt = _exc_to_text(args.exc_type, args.exc_value, args.exc_traceback)
-            except Exception:
-                txt = f"{args}"
-            log("== Thread exception ==\n" + txt)
-        threading.excepthook = _thook
+                qInstallMessageHandler(_qt_message_handler)
+                _LOGGER.debug("Qt message handler instalado (respetando QT_LOGGING_RULES existentes)")
+            except Exception as e:
+                _LOGGER.warning("No se pudo instalar qInstallMessageHandler: %s", e)
+
+        _INSTALLED = True
+        _LOGGER.info("ErrorGuard instalado. %s", _fmt_env())
+    else:
+        _LOGGER.debug("ErrorGuard ya instalado; se omite reinstalación.")
+
+    return _LOGGER
+
+# Alias para compatibilidad con tu app.py existente
+def install(verbose: bool = False, app_name: str = "buildtool", logs_dir: Optional[str] = None) -> None:
+    install_error_guard(app_name=app_name, logs_dir=logs_dir, verbose=verbose)
+
+def on_about_to_quit_flush() -> None:
+    """Vacía buffers y cierra archivos al apagar la app."""
     try:
-        import asyncio
-        loop = asyncio.get_event_loop()
-        def _ah(loop, context):
-            exc = context.get("exception")
-            if exc:
-                txt = "".join(traceback.format_exception(type(exc), exc, exc.__traceback__))
-                log("== Asyncio exception ==\n" + txt)
-            else:
-                log("== Asyncio error == " + str(context))
-        loop.set_exception_handler(_ah)
+        logging.shutdown()
     except Exception:
         pass
-    _install_qt_handler()
-    _installed = True
-    if verbose:
-        log("== errguard: installed (verbose) ==")
+    try:
+        if _FAULT_FILE:
+            _FAULT_FILE.flush()
+            _FAULT_FILE.close()
+    except Exception:
+        pass
+
+# Logging helper público
+def log(msg: str, level: int = logging.INFO) -> None:
+    if _LOGGER is None:
+        # Inicialización perezosa para no perder mensajes tempranos
+        install_error_guard(_APP_NAME, None, verbose=False)
+    try:
+        _LOGGER.log(level, msg)
+    except Exception:
+        # Evita que el logging mismo truene la app
+        try:
+            sys.stderr.write(msg + "\n")
+        except Exception:
+            pass
+
+def get_logger() -> logging.Logger:
+    if _LOGGER is None:
+        return install_error_guard(_APP_NAME, None, verbose=False)
+    return _LOGGER

--- a/buildtool/core/qt_silence.py
+++ b/buildtool/core/qt_silence.py
@@ -1,4 +1,3 @@
-
 # buildtool/core/qt_silence.py
 import os, warnings
 try:
@@ -15,12 +14,10 @@ _RULES = {
 def setup_qt_logging(level: str = "warn") -> None:
     rules = _RULES.get((level or "warn").lower(), _RULES["warn"])
     os.environ["QT_LOGGING_RULES"] = rules.replace("\n", ";")
+
     if QtCore and hasattr(QtCore, "QLoggingCategory"):
         QtCore.QLoggingCategory.setFilterRules(rules)
-    if QtCore and hasattr(QtCore, "qInstallMessageHandler"):
-        def _handler(mode, context, message):
-            if mode in (QtCore.QtMsgType.QtDebugMsg, QtCore.QtMsgType.QtInfoMsg):
-                return
-        QtCore.qInstallMessageHandler(_handler)
+
+    # Silenciar warnings de Python
     warnings.filterwarnings("ignore", category=DeprecationWarning)
     warnings.filterwarnings("ignore", category=ResourceWarning)

--- a/buildtool/tests/errguard_smoke.py
+++ b/buildtool/tests/errguard_smoke.py
@@ -1,0 +1,45 @@
+# buildtool/tests/errguard_smoke.py
+from __future__ import annotations
+import sys, threading, asyncio, time
+from buildtool.core.errguard import install_error_guard, log, on_about_to_quit_flush
+
+def uncaught_exception():
+    # Esto debe ser capturado por sys.excepthook de errguard
+    raise RuntimeError("SMOKE: uncaught_exception()")
+
+def thread_crash():
+    def _t():
+        raise ValueError("SMOKE: thread_crash() in worker thread")
+    th = threading.Thread(target=_t, name="smoke-thread")
+    th.start()
+    th.join()
+
+def asyncio_crash():
+    async def boom():
+        await asyncio.sleep(0.01)
+        raise LookupError("SMOKE: asyncio_crash() in task")
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    loop.set_exception_handler(lambda l, c: log(f"Loop handler caught: {c}", level=30))  # WARNING
+    loop.create_task(boom())
+    try:
+        loop.run_until_complete(asyncio.sleep(0.05))
+    finally:
+        loop.close()
+
+def main():
+    install_error_guard(app_name="buildtool", verbose=True)
+    log("== SMOKE CLI start ==")
+
+    # 1) Excepción en hilo
+    thread_crash()
+    # 2) Excepción en asyncio
+    asyncio_crash()
+    # 3) Excepción no atrapada (al final, para no cortar antes)
+    try:
+        uncaught_exception()
+    finally:
+        on_about_to_quit_flush()
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
# PySide6: **guard de errores** global + **fixes de concurrencia** en `GitView` (evita cierres abruptos)

### Contexto
- Se producían cierres abruptos (p. ej. **Windows fatal exception: access violation**) al actualizar la UI desde hilos en background.
- La trazabilidad de mensajes/errores de Qt no siempre quedaba consistente.

### Cambios principales
- **`buildtool/core/errguard.py`**
  - Hooks globales: `sys.excepthook`, `threading.excepthook`, handler de `asyncio`.
  - **Qt:** `qInstallMessageHandler` único (centraliza logs de Qt).
  - **Logs:** rotativos a `buildtool.log` + salida a `stderr`.
  - **Faulthandler:** activado a `buildtool_faults.log`.
  - `on_about_to_quit_flush()` para flush y cierre ordenado.

- **`buildtool/core/qt_silence.py`**
  - Define **reglas de filtrado** (`QT_LOGGING_RULES` / `QLoggingCategory`) para reducir ruido.
  - **No** instala su propio message handler (evita conflictos con `errguard`).

- **`buildtool/app.py`**
  - **Orden de arranque corregido:** `install_error_guard()` → `setup_qt_logging()` → crear `QApplication`.
  - Conexión `aboutToQuit` → `on_about_to_quit_flush()` (flush de logs/faults).
  - Bitácora opcional en `~/forgebuild_crash.log`.
  - Apagado ordenado de hilos con `TRACKER.stop_all(...)`.

- **`buildtool/views/git_view.py`**
  - **UI solo en hilo principal:**
    - `worker.finished.connect(self._on_task_finish, Qt.QueuedConnection)`.
    - `@QtCore.Slot(bool) def _on_task_finish(...)` actualiza UI.
  - `_refresh_history()` / `_refresh_summary()`:
    - `QSignalBlocker`, `setUpdatesEnabled(False/True)`, `shiboken6.isValid(...)`.
  - **Regla:** los workers devuelven **datos puros** (sin QObjects); la construcción de `QTreeWidgetItem`/íconos se hace en UI.
  - Limpieza segura de `QThread`/`QObject` al finalizar (sin tocar UI desde el hilo worker).

### Beneficios
- Evita **crashes** por acceso a UI desde hilos de background.
- **Trazabilidad** consistente de Qt y Python (logs centralizados).
- **Cierre limpio** con flush garantizado de logs y fault traces.

### Pruebas
- **CLI:** `python -m buildtool.tests.errguard_smoke`  
  - Registra excepción en hilo (`CRITICAL`), error en asyncio y uncaught del main con ENV + traceback.
- **Manual (GUI):** tareas en `GitView` sin reproducir *access violation*; warnings de Qt visibles en `buildtool.log`.

### Checklist
- [x] **Sin QObjects en workers** (solo datos).
- [x] **UI exclusiva en hilo principal** (slots con `Qt.QueuedConnection`).
- [x] **Un solo** `qInstallMessageHandler` (el de `errguard`).
- [x] `on_about_to_quit_flush()` conectado.
- [x] Logs verificados en `./.forgebuild/logs/`.

### Notas
- Si se usa `qasync`, re-asignar el handler de `asyncio` tras crear el event loop.
- En entornos con GPU/driver problemáticos, considerar `QT_OPENGL=software`.
