### PR TITLE
feat: expose branch history in git view

### DIFF
--- a/buildtool/core/branch_store.py
+++ b/buildtool/core/branch_store.py
@@ -1,0 +1,259 @@
+from __future__ import annotations
+from dataclasses import dataclass, asdict
+from pathlib import Path
+from typing import Dict, Optional, List
+import json
+import os
+import time
+
+from .config import load_config
+
+# ---------------- paths helpers -----------------
+
+def _root_dir() -> Path:
+    try:
+        return Path(__file__).resolve().parents[2]
+    except Exception:
+        return Path.cwd()
+
+
+def _state_dir() -> Path:
+    base = os.environ.get("APPDATA")
+    if base:
+        d = Path(base) / "forgebuild"
+    else:
+        d = Path(os.environ.get("XDG_DATA_HOME", Path.home() / ".local" / "share")) / "forgebuild"
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def _nas_dir() -> Path:
+    cfg = load_config()
+    base = getattr(getattr(cfg, "paths", {}), "nas_dir", "")
+    if not base:
+        base = os.environ.get("NAS_DIR")
+    if not base:
+        base = str(_root_dir() / "_nas_dev")
+    p = Path(base)
+    p.mkdir(parents=True, exist_ok=True)
+    return p
+
+
+def _index_path(base: Path) -> Path:
+    return base / "branches_index.json"
+
+
+def _log_path(base: Path) -> Path:
+    return base / "activity_log.jsonl"
+
+
+# ---------------- data structures -----------------
+
+@dataclass
+class BranchRecord:
+    branch: str
+    group: Optional[str] = None
+    project: Optional[str] = None
+    created_at: int = 0
+    created_by: str = ""
+    exists_local: bool = True
+    exists_origin: bool = False
+    merge_status: str = "none"
+    diverged: Optional[bool] = None
+    stale_days: Optional[int] = None
+    last_action: str = "create"
+    last_updated_at: int = 0
+    last_updated_by: str = ""
+
+    def key(self) -> str:
+        return f"{self.group or ''}/{self.project or ''}/{self.branch}"
+
+
+Index = Dict[str, BranchRecord]
+
+
+# ---------------- index persistence -----------------
+
+def load_index(path: Optional[Path] = None) -> Index:
+    p = path or _index_path(_state_dir())
+    if not p.exists():
+        return {}
+    try:
+        raw = json.loads(p.read_text(encoding="utf-8"))
+    except Exception:
+        return {}
+    items = {}
+    for rec in raw.get("items", []):
+        try:
+            br = BranchRecord(**rec)
+            items[br.key()] = br
+        except Exception:
+            continue
+    return items
+
+
+def save_index(index: Index, path: Optional[Path] = None) -> None:
+    p = path or _index_path(_state_dir())
+    tmp = p.with_suffix(".tmp")
+    payload = {"version": 1, "items": [asdict(v) for v in index.values()]}
+    tmp.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+    tmp.replace(p)
+
+
+# ---------------- activity log -----------------
+
+def _load_log(path: Path) -> List[str]:
+    if not path.exists():
+        return []
+    try:
+        return path.read_text(encoding="utf-8").splitlines()
+    except Exception:
+        return []
+
+
+def _append_log(lines: List[str], path: Path) -> None:
+    with path.open("a", encoding="utf-8") as fh:
+        for ln in lines:
+            fh.write(ln + "\n")
+
+
+def record_activity(action: str, rec: BranchRecord, result: str = "ok", message: str = "") -> None:
+    entry = {
+        "ts": int(time.time()),
+        "user": rec.last_updated_by or rec.created_by,
+        "group": rec.group,
+        "project": rec.project,
+        "branch": rec.branch,
+        "action": action,
+        "result": result,
+        "message": message,
+    }
+    p = _log_path(_state_dir())
+    _append_log([json.dumps(entry, ensure_ascii=False)], p)
+
+
+# ---------------- basic mutations -----------------
+
+def upsert(rec: BranchRecord, index: Optional[Index] = None, action: str = "upsert") -> Index:
+    idx = index or load_index()
+    now = int(time.time())
+    rec.last_updated_at = now
+    if not rec.created_at:
+        rec.created_at = now
+    idx[rec.key()] = rec
+    save_index(idx)
+    record_activity(action, rec)
+    return idx
+
+
+def remove(rec: BranchRecord, index: Optional[Index] = None) -> Index:
+    idx = index or load_index()
+    idx.pop(rec.key(), None)
+    save_index(idx)
+    record_activity("remove", rec)
+    return idx
+
+
+# ---------------- filtering helpers -----------------
+
+def _filter_origin(index: Index) -> Index:
+    """Keep only records that were pushed to origin."""
+    return {k: v for k, v in index.items() if v.exists_origin}
+
+
+def _filter_log_by_index(lines: List[str], index: Index) -> List[str]:
+    keys = set(index.keys())
+    out: List[str] = []
+    for ln in lines:
+        try:
+            entry = json.loads(ln)
+            key = f"{entry.get('group') or ''}/{entry.get('project') or ''}/{entry.get('branch') or ''}"
+        except Exception:
+            continue
+        if key in keys:
+            out.append(ln)
+    return out
+
+
+# ---------------- NAS sync -----------------
+
+LOCK_NAME = "branches.lock"
+
+
+def _acquire_lock(base: Path, timeout: int = 10) -> bool:
+    lock = base / LOCK_NAME
+    start = time.time()
+    while lock.exists() and time.time() - start < timeout:
+        time.sleep(0.1)
+    try:
+        lock.write_text(str(os.getpid()))
+        return True
+    except Exception:
+        return False
+
+
+def _release_lock(base: Path) -> None:
+    try:
+        (base / LOCK_NAME).unlink()
+    except Exception:
+        pass
+
+
+def recover_from_nas() -> Index:
+    base = _nas_dir()
+    local = load_index()
+    nas = _filter_origin(load_index(_index_path(base)))
+    merged = merge_indexes(local, nas)
+    save_index(merged)
+
+    # merge activity log
+    local_log = _load_log(_log_path(_state_dir()))
+    nas_log_raw = _load_log(_log_path(base))
+    nas_log = _filter_log_by_index(nas_log_raw, nas)
+    seen = set(local_log)
+    new_lines = [ln for ln in nas_log if ln not in seen]
+    if new_lines:
+        _append_log(new_lines, _log_path(_state_dir()))
+    return merged
+
+
+def publish_to_nas() -> Index:
+    base = _nas_dir()
+    if not _acquire_lock(base):
+        raise RuntimeError("NAS lock busy")
+    try:
+        local = _filter_origin(load_index())
+        remote = _filter_origin(load_index(_index_path(base)))
+        merged = merge_indexes(remote, local)
+        save_index(merged, _index_path(base))
+
+        # publish activity log
+        base_log = _log_path(base)
+        local_log_raw = _load_log(_log_path(_state_dir()))
+        local_log = _filter_log_by_index(local_log_raw, local)
+        remote_log_raw = _load_log(base_log)
+        remote_log = _filter_log_by_index(remote_log_raw, remote)
+        if remote_log != remote_log_raw:
+            base_log.write_text("\n".join(remote_log) + ("\n" if remote_log else ""), encoding="utf-8")
+        seen = set(remote_log)
+        new_lines = [ln for ln in local_log if ln not in seen]
+        if new_lines:
+            _append_log(new_lines, base_log)
+        return merged
+    finally:
+        _release_lock(base)
+
+
+# ---------------- merging -----------------
+
+def merge_indexes(a: Index, b: Index) -> Index:
+    out: Index = {}
+    out.update(a)
+    for key, rec in b.items():
+        if key not in out:
+            out[key] = rec
+            continue
+        existing = out[key]
+        if rec.last_updated_at >= existing.last_updated_at:
+            out[key] = rec
+    return out

--- a/buildtool/core/config.py
+++ b/buildtool/core/config.py
@@ -7,6 +7,7 @@ import yaml, pathlib
 class Paths(BaseModel):
     workspaces: Dict[str, str] = Field(default_factory=dict)
     output_base: str = ""
+    nas_dir: str = ""
 
 class Module(BaseModel):
     version_files: List[str] = Field(default_factory=list)  # archivos relativos al módulo para actualizar versión
@@ -67,7 +68,7 @@ def load_config() -> Config:
             data = yaml.safe_load(f) or {}
         return Config(**data)
     # default
-    return Config(paths=Paths(workspaces={}, output_base=""))
+    return Config(paths=Paths(workspaces={}, output_base="", nas_dir=""))
 
 def save_config(cfg: Config) -> str:
     # v1 usa .dict(), v2 usa .model_dump()

--- a/buildtool/core/git_tasks_local.py
+++ b/buildtool/core/git_tasks_local.py
@@ -7,7 +7,15 @@ from pathlib import Path
 from typing import Optional, Iterable, Tuple, List, Iterator
 import os
 import subprocess
+import getpass
 
+from buildtool.core.branch_store import (
+    BranchRecord,
+    load_index,
+    upsert,
+    remove,
+    record_activity,
+)
 from buildtool.core.git_console_trace import clog
 
 # --------------------- helpers de salida y ejecución ---------------------
@@ -44,6 +52,19 @@ def _run(cmd: List[str], cwd: Path, emit=None) -> Tuple[int, str]:
     rc = p.wait()
     _out(emit, f"[rc={rc}] {' '.join(cmd)}")
     return rc, out
+
+
+def _current_user() -> str:
+    return os.environ.get("USERNAME") or os.environ.get("USER") or getpass.getuser()
+
+
+def _get_record(index, gkey, pkey, branch) -> BranchRecord:
+    key = f"{gkey or ''}/{pkey or ''}/{branch}"
+    rec = index.get(key)
+    if not rec:
+        user = _current_user()
+        rec = BranchRecord(branch=branch, group=gkey, project=pkey, created_by=user, last_updated_by=user)
+    return rec
 
 
 def _is_git_repo(path: Path, emit=None) -> bool:
@@ -200,6 +221,13 @@ def create_branches_local(
             ok_all = False
         else:
             _out(emit, f"[{mname}] ✅ rama lista: {bname}")
+    if ok_all:
+        idx = load_index()
+        rec = _get_record(idx, gkey, pkey, bname)
+        rec.exists_local = True
+        rec.last_action = "create_local"
+        rec.last_updated_by = _current_user()
+        upsert(rec, idx, action="create_local")
     return ok_all
 
 
@@ -237,6 +265,13 @@ def switch_branch(
                 _out(emit, f"[{mname}] ✅ switch con checkout: {bname}")
         else:
             _out(emit, f"[{mname}] ✅ switch: {bname}")
+    if ok_all:
+        idx = load_index()
+        rec = _get_record(idx, gkey, pkey, bname)
+        rec.exists_local = True
+        rec.last_action = "switch"
+        rec.last_updated_by = _current_user()
+        upsert(rec, idx, action="switch")
     return ok_all
 
 
@@ -263,7 +298,41 @@ def delete_local_branch_by_name(
             ok_all = False
         else:
             _out(emit, f"[{mname}] 🗑️ rama eliminada: {bname}")
-    return ok_all
+    idx = load_index()
+    key_rec = f"{gkey or ''}/{pkey or ''}/{bname}"
+    rec = idx.get(key_rec)
+    if not ok_all:
+        if rec:
+            rec.last_updated_by = _current_user()
+            record_activity(
+                "delete_local", rec, result="error", message="git branch delete failed"
+            )
+        return False
+
+    exists_local = False
+    exists_origin = False
+    for mname, mpath in repos:
+        if _is_git_repo(mpath):
+            rc, _ = _run(["git", "show-ref", "--verify", "--quiet", f"refs/heads/{bname}"], mpath)
+            if rc == 0:
+                exists_local = True
+            rc2, _ = _run(["git", "ls-remote", "--exit-code", "--heads", "origin", bname], mpath)
+            if rc2 == 0:
+                exists_origin = True
+
+    if exists_origin:
+        if not rec:
+            rec = BranchRecord(branch=bname, group=gkey, project=pkey, created_by=_current_user())
+        rec.exists_local = exists_local
+        rec.exists_origin = True
+        rec.last_action = "delete_local" if not exists_local else rec.last_action
+        rec.last_updated_by = _current_user()
+        upsert(rec, idx, action="delete_local" if not exists_local else "update")
+    else:
+        if rec:
+            rec.last_updated_by = _current_user()
+            remove(rec, idx)
+    return True
 
 
 def push_branch(
@@ -275,6 +344,20 @@ def push_branch(
         raise RuntimeError("Nombre de rama vacío en push.")
 
     repos = _discover_repos(cfg, gkey, pkey, only_modules, emit=emit)
+    if repos:
+        first = repos[0][1]
+        if _is_git_repo(first):
+            rc, _ = _run(["git", "ls-remote", "--exit-code", "--heads", "origin", bname], first)
+            if rc == 0:
+                _out(emit, f"La rama ya existe en origin: {bname}")
+                idx = load_index()
+                rec = _get_record(idx, gkey, pkey, bname)
+                rec.exists_local = True
+                rec.exists_origin = True
+                rec.last_action = "push_skip"
+                rec.last_updated_by = _current_user()
+                upsert(rec, idx, action="push_skip")
+                return False
     ok_all = True
     for mname, mpath in repos:
         if not _is_git_repo(mpath, emit=emit):
@@ -288,4 +371,20 @@ def push_branch(
             ok_all = False
         else:
             _out(emit, f"[{mname}] ☁️ push origin {bname}")
+
+    exists_origin = False
+    for _, mpath in repos:
+        if _is_git_repo(mpath):
+            rc, _ = _run(["git", "ls-remote", "--exit-code", "--heads", "origin", bname], mpath)
+            if rc == 0:
+                exists_origin = True
+                break
+
+    idx = load_index()
+    rec = _get_record(idx, gkey, pkey, bname)
+    rec.exists_local = True
+    rec.exists_origin = exists_origin
+    rec.last_action = "push_origin" if ok_all else "push_failed"
+    rec.last_updated_by = _current_user()
+    upsert(rec, idx, action=rec.last_action)
     return ok_all

--- a/buildtool/data/config.yaml
+++ b/buildtool/data/config.yaml
@@ -1,4 +1,5 @@
 paths:
+  nas_dir: C:/NAS/forgebuild
   workspaces:
     PDF: C:/Proyectos/PDF
   output_base: C:/Users/licen/Documents/Compiladores/Paquetes


### PR DESCRIPTION
## Summary
- show shared branch history and statuses within Git view
- add buttons to recover and publish branch index to NAS
- populate branch selectors from centralized branch index
- restrict NAS sync to branches already pushed to origin
- display branch creator and rename project summary section
- move console output to a dedicated tab with a clear button

## Testing
- `python -m py_compile buildtool/core/branch_store.py buildtool/core/git_tasks_local.py buildtool/views/git_view.py`


------
https://chatgpt.com/codex/tasks/task_e_68c756fc3c64832cb0e2739ef6850b13