### PR TITLE
feat: expose branch history in git view

### DIFF
--- a/buildtool/core/branch_store.py
+++ b/buildtool/core/branch_store.py
@@ -1,0 +1,259 @@
+from __future__ import annotations
+from dataclasses import dataclass, asdict
+from pathlib import Path
+from typing import Dict, Optional, List
+import json
+import os
+import time
+
+from .config import load_config
+
+# ---------------- paths helpers -----------------
+
+def _root_dir() -> Path:
+    try:
+        return Path(__file__).resolve().parents[2]
+    except Exception:
+        return Path.cwd()
+
+
+def _state_dir() -> Path:
+    base = os.environ.get("APPDATA")
+    if base:
+        d = Path(base) / "forgebuild"
+    else:
+        d = Path(os.environ.get("XDG_DATA_HOME", Path.home() / ".local" / "share")) / "forgebuild"
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def _nas_dir() -> Path:
+    cfg = load_config()
+    base = getattr(getattr(cfg, "paths", {}), "nas_dir", "")
+    if not base:
+        base = os.environ.get("NAS_DIR")
+    if not base:
+        base = str(_root_dir() / "_nas_dev")
+    p = Path(base)
+    p.mkdir(parents=True, exist_ok=True)
+    return p
+
+
+def _index_path(base: Path) -> Path:
+    return base / "branches_index.json"
+
+
+def _log_path(base: Path) -> Path:
+    return base / "activity_log.jsonl"
+
+
+# ---------------- data structures -----------------
+
+@dataclass
+class BranchRecord:
+    branch: str
+    group: Optional[str] = None
+    project: Optional[str] = None
+    created_at: int = 0
+    created_by: str = ""
+    exists_local: bool = True
+    exists_origin: bool = False
+    merge_status: str = "none"
+    diverged: Optional[bool] = None
+    stale_days: Optional[int] = None
+    last_action: str = "create"
+    last_updated_at: int = 0
+    last_updated_by: str = ""
+
+    def key(self) -> str:
+        return f"{self.group or ''}/{self.project or ''}/{self.branch}"
+
+
+Index = Dict[str, BranchRecord]
+
+
+# ---------------- index persistence -----------------
+
+def load_index(path: Optional[Path] = None) -> Index:
+    p = path or _index_path(_state_dir())
+    if not p.exists():
+        return {}
+    try:
+        raw = json.loads(p.read_text(encoding="utf-8"))
+    except Exception:
+        return {}
+    items = {}
+    for rec in raw.get("items", []):
+        try:
+            br = BranchRecord(**rec)
+            items[br.key()] = br
+        except Exception:
+            continue
+    return items
+
+
+def save_index(index: Index, path: Optional[Path] = None) -> None:
+    p = path or _index_path(_state_dir())
+    tmp = p.with_suffix(".tmp")
+    payload = {"version": 1, "items": [asdict(v) for v in index.values()]}
+    tmp.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+    tmp.replace(p)
+
+
+# ---------------- activity log -----------------
+
+def _load_log(path: Path) -> List[str]:
+    if not path.exists():
+        return []
+    try:
+        return path.read_text(encoding="utf-8").splitlines()
+    except Exception:
+        return []
+
+
+def _append_log(lines: List[str], path: Path) -> None:
+    with path.open("a", encoding="utf-8") as fh:
+        for ln in lines:
+            fh.write(ln + "\n")
+
+
+def record_activity(action: str, rec: BranchRecord, result: str = "ok", message: str = "") -> None:
+    entry = {
+        "ts": int(time.time()),
+        "user": rec.last_updated_by or rec.created_by,
+        "group": rec.group,
+        "project": rec.project,
+        "branch": rec.branch,
+        "action": action,
+        "result": result,
+        "message": message,
+    }
+    p = _log_path(_state_dir())
+    _append_log([json.dumps(entry, ensure_ascii=False)], p)
+
+
+# ---------------- basic mutations -----------------
+
+def upsert(rec: BranchRecord, index: Optional[Index] = None, action: str = "upsert") -> Index:
+    idx = index or load_index()
+    now = int(time.time())
+    rec.last_updated_at = now
+    if not rec.created_at:
+        rec.created_at = now
+    idx[rec.key()] = rec
+    save_index(idx)
+    record_activity(action, rec)
+    return idx
+
+
+def remove(rec: BranchRecord, index: Optional[Index] = None) -> Index:
+    idx = index or load_index()
+    idx.pop(rec.key(), None)
+    save_index(idx)
+    record_activity("remove", rec)
+    return idx
+
+
+# ---------------- filtering helpers -----------------
+
+def _filter_origin(index: Index) -> Index:
+    """Keep only records that were pushed to origin."""
+    return {k: v for k, v in index.items() if v.exists_origin}
+
+
+def _filter_log_by_index(lines: List[str], index: Index) -> List[str]:
+    keys = set(index.keys())
+    out: List[str] = []
+    for ln in lines:
+        try:
+            entry = json.loads(ln)
+            key = f"{entry.get('group') or ''}/{entry.get('project') or ''}/{entry.get('branch') or ''}"
+        except Exception:
+            continue
+        if key in keys:
+            out.append(ln)
+    return out
+
+
+# ---------------- NAS sync -----------------
+
+LOCK_NAME = "branches.lock"
+
+
+def _acquire_lock(base: Path, timeout: int = 10) -> bool:
+    lock = base / LOCK_NAME
+    start = time.time()
+    while lock.exists() and time.time() - start < timeout:
+        time.sleep(0.1)
+    try:
+        lock.write_text(str(os.getpid()))
+        return True
+    except Exception:
+        return False
+
+
+def _release_lock(base: Path) -> None:
+    try:
+        (base / LOCK_NAME).unlink()
+    except Exception:
+        pass
+
+
+def recover_from_nas() -> Index:
+    base = _nas_dir()
+    local = load_index()
+    nas = _filter_origin(load_index(_index_path(base)))
+    merged = merge_indexes(local, nas)
+    save_index(merged)
+
+    # merge activity log
+    local_log = _load_log(_log_path(_state_dir()))
+    nas_log_raw = _load_log(_log_path(base))
+    nas_log = _filter_log_by_index(nas_log_raw, nas)
+    seen = set(local_log)
+    new_lines = [ln for ln in nas_log if ln not in seen]
+    if new_lines:
+        _append_log(new_lines, _log_path(_state_dir()))
+    return merged
+
+
+def publish_to_nas() -> Index:
+    base = _nas_dir()
+    if not _acquire_lock(base):
+        raise RuntimeError("NAS lock busy")
+    try:
+        local = _filter_origin(load_index())
+        remote = _filter_origin(load_index(_index_path(base)))
+        merged = merge_indexes(remote, local)
+        save_index(merged, _index_path(base))
+
+        # publish activity log
+        base_log = _log_path(base)
+        local_log_raw = _load_log(_log_path(_state_dir()))
+        local_log = _filter_log_by_index(local_log_raw, local)
+        remote_log_raw = _load_log(base_log)
+        remote_log = _filter_log_by_index(remote_log_raw, remote)
+        if remote_log != remote_log_raw:
+            base_log.write_text("\n".join(remote_log) + ("\n" if remote_log else ""), encoding="utf-8")
+        seen = set(remote_log)
+        new_lines = [ln for ln in local_log if ln not in seen]
+        if new_lines:
+            _append_log(new_lines, base_log)
+        return merged
+    finally:
+        _release_lock(base)
+
+
+# ---------------- merging -----------------
+
+def merge_indexes(a: Index, b: Index) -> Index:
+    out: Index = {}
+    out.update(a)
+    for key, rec in b.items():
+        if key not in out:
+            out[key] = rec
+            continue
+        existing = out[key]
+        if rec.last_updated_at >= existing.last_updated_at:
+            out[key] = rec
+    return out

--- a/buildtool/core/config.py
+++ b/buildtool/core/config.py
@@ -7,6 +7,7 @@ import yaml, pathlib
 class Paths(BaseModel):
     workspaces: Dict[str, str] = Field(default_factory=dict)
     output_base: str = ""
+    nas_dir: str = ""
 
 class Module(BaseModel):
     version_files: List[str] = Field(default_factory=list)  # archivos relativos al módulo para actualizar versión
@@ -67,7 +68,7 @@ def load_config() -> Config:
             data = yaml.safe_load(f) or {}
         return Config(**data)
     # default
-    return Config(paths=Paths(workspaces={}, output_base=""))
+    return Config(paths=Paths(workspaces={}, output_base="", nas_dir=""))
 
 def save_config(cfg: Config) -> str:
     # v1 usa .dict(), v2 usa .model_dump()

--- a/buildtool/core/git_tasks_local.py
+++ b/buildtool/core/git_tasks_local.py
@@ -7,7 +7,15 @@ from pathlib import Path
 from typing import Optional, Iterable, Tuple, List, Iterator
 import os
 import subprocess
+import getpass
 
+from buildtool.core.branch_store import (
+    BranchRecord,
+    load_index,
+    upsert,
+    remove,
+    record_activity,
+)
 from buildtool.core.git_console_trace import clog
 
 # --------------------- helpers de salida y ejecución ---------------------
@@ -44,6 +52,19 @@ def _run(cmd: List[str], cwd: Path, emit=None) -> Tuple[int, str]:
     rc = p.wait()
     _out(emit, f"[rc={rc}] {' '.join(cmd)}")
     return rc, out
+
+
+def _current_user() -> str:
+    return os.environ.get("USERNAME") or os.environ.get("USER") or getpass.getuser()
+
+
+def _get_record(index, gkey, pkey, branch) -> BranchRecord:
+    key = f"{gkey or ''}/{pkey or ''}/{branch}"
+    rec = index.get(key)
+    if not rec:
+        user = _current_user()
+        rec = BranchRecord(branch=branch, group=gkey, project=pkey, created_by=user, last_updated_by=user)
+    return rec
 
 
 def _is_git_repo(path: Path, emit=None) -> bool:
@@ -200,6 +221,13 @@ def create_branches_local(
             ok_all = False
         else:
             _out(emit, f"[{mname}] ✅ rama lista: {bname}")
+    if ok_all:
+        idx = load_index()
+        rec = _get_record(idx, gkey, pkey, bname)
+        rec.exists_local = True
+        rec.last_action = "create_local"
+        rec.last_updated_by = _current_user()
+        upsert(rec, idx, action="create_local")
     return ok_all
 
 
@@ -237,6 +265,13 @@ def switch_branch(
                 _out(emit, f"[{mname}] ✅ switch con checkout: {bname}")
         else:
             _out(emit, f"[{mname}] ✅ switch: {bname}")
+    if ok_all:
+        idx = load_index()
+        rec = _get_record(idx, gkey, pkey, bname)
+        rec.exists_local = True
+        rec.last_action = "switch"
+        rec.last_updated_by = _current_user()
+        upsert(rec, idx, action="switch")
     return ok_all
 
 
@@ -263,7 +298,41 @@ def delete_local_branch_by_name(
             ok_all = False
         else:
             _out(emit, f"[{mname}] 🗑️ rama eliminada: {bname}")
-    return ok_all
+    idx = load_index()
+    key_rec = f"{gkey or ''}/{pkey or ''}/{bname}"
+    rec = idx.get(key_rec)
+    if not ok_all:
+        if rec:
+            rec.last_updated_by = _current_user()
+            record_activity(
+                "delete_local", rec, result="error", message="git branch delete failed"
+            )
+        return False
+
+    exists_local = False
+    exists_origin = False
+    for mname, mpath in repos:
+        if _is_git_repo(mpath):
+            rc, _ = _run(["git", "show-ref", "--verify", "--quiet", f"refs/heads/{bname}"], mpath)
+            if rc == 0:
+                exists_local = True
+            rc2, _ = _run(["git", "ls-remote", "--exit-code", "--heads", "origin", bname], mpath)
+            if rc2 == 0:
+                exists_origin = True
+
+    if exists_origin:
+        if not rec:
+            rec = BranchRecord(branch=bname, group=gkey, project=pkey, created_by=_current_user())
+        rec.exists_local = exists_local
+        rec.exists_origin = True
+        rec.last_action = "delete_local" if not exists_local else rec.last_action
+        rec.last_updated_by = _current_user()
+        upsert(rec, idx, action="delete_local" if not exists_local else "update")
+    else:
+        if rec:
+            rec.last_updated_by = _current_user()
+            remove(rec, idx)
+    return True
 
 
 def push_branch(
@@ -275,6 +344,20 @@ def push_branch(
         raise RuntimeError("Nombre de rama vacío en push.")
 
     repos = _discover_repos(cfg, gkey, pkey, only_modules, emit=emit)
+    if repos:
+        first = repos[0][1]
+        if _is_git_repo(first):
+            rc, _ = _run(["git", "ls-remote", "--exit-code", "--heads", "origin", bname], first)
+            if rc == 0:
+                _out(emit, f"La rama ya existe en origin: {bname}")
+                idx = load_index()
+                rec = _get_record(idx, gkey, pkey, bname)
+                rec.exists_local = True
+                rec.exists_origin = True
+                rec.last_action = "push_skip"
+                rec.last_updated_by = _current_user()
+                upsert(rec, idx, action="push_skip")
+                return False
     ok_all = True
     for mname, mpath in repos:
         if not _is_git_repo(mpath, emit=emit):
@@ -288,4 +371,20 @@ def push_branch(
             ok_all = False
         else:
             _out(emit, f"[{mname}] ☁️ push origin {bname}")
+
+    exists_origin = False
+    for _, mpath in repos:
+        if _is_git_repo(mpath):
+            rc, _ = _run(["git", "ls-remote", "--exit-code", "--heads", "origin", bname], mpath)
+            if rc == 0:
+                exists_origin = True
+                break
+
+    idx = load_index()
+    rec = _get_record(idx, gkey, pkey, bname)
+    rec.exists_local = True
+    rec.exists_origin = exists_origin
+    rec.last_action = "push_origin" if ok_all else "push_failed"
+    rec.last_updated_by = _current_user()
+    upsert(rec, idx, action=rec.last_action)
     return ok_all

--- a/buildtool/data/config.yaml
+++ b/buildtool/data/config.yaml
@@ -1,4 +1,5 @@
 paths:
+  nas_dir: C:/NAS/forgebuild
   workspaces:
     PDF: C:/Proyectos/PDF
   output_base: C:/Users/licen/Documents/Compiladores/Paquetes

--- a/buildtool/views/git_view.py
+++ b/buildtool/views/git_view.py
@@ -5,8 +5,22 @@ import os
 from pathlib import Path
 from functools import wraps
 from PySide6.QtWidgets import (
-    QWidget, QVBoxLayout, QGridLayout, QLabel, QComboBox, QLineEdit,
-    QPushButton, QCheckBox, QTextEdit, QHBoxLayout, QGroupBox, QTreeWidget, QTreeWidgetItem, QApplication
+    QWidget,
+    QVBoxLayout,
+    QGridLayout,
+    QLabel,
+    QComboBox,
+    QLineEdit,
+    QPushButton,
+    QCheckBox,
+    QTextEdit,
+    QHBoxLayout,
+    QGroupBox,
+    QTreeWidget,
+    QTreeWidgetItem,
+    QApplication,
+    QTabWidget,
+    QMessageBox,
 )
 from PySide6.QtCore import Qt, Signal, QObject, QTimer
 from ..core.config import Config
@@ -20,8 +34,11 @@ from ..core.bg import run_in_thread
 from ..core.discover import discover_status_fast
 from ..core.state import STATE
 from PySide6 import QtCore, QtWidgets
+from datetime import datetime
+from ..core.git_fast import get_current_branch_fast
 import shiboken6
 from buildtool.core import errguard
+from ..core.branch_store import load_index, recover_from_nas, publish_to_nas
 
 def safe_slot(fn: Callable):
     @wraps(fn)
@@ -69,7 +86,8 @@ class GitView(QWidget):
 
     def _set_busy(self, busy: bool, note: str = ""):
         for w in (self.btnCreateLocal, self.btnPushBranch, self.btnDeleteBranch,
-                  self.btnRunCreateVersion, self.btnSwitch, self.btnRefresh, self.btnReconcile):
+                  self.btnRunCreateVersion, self.btnSwitch, self.btnRefresh,
+                  self.btnReconcile, self.btnNasRecover, self.btnNasPublish):
             try: w.setEnabled(not busy)
             except Exception: pass
         try:
@@ -83,51 +101,100 @@ class GitView(QWidget):
         if note:
             self.logger.line.emit(note)
 
-    def _setup_ui(self):
-        root = QVBoxLayout(self); root.setContentsMargins(8,8,8,8); root.setSpacing(8)
-        top = QGridLayout(); top.setHorizontalSpacing(8); top.setVerticalSpacing(6)
-        row = 0
-        top.addWidget(QLabel("Proyecto:"), row, 0)
-        self.cboProject = QComboBox(); top.addWidget(self.cboProject, row, 1); row += 1
+    def _alert(self, msg: str, error: bool = False):
+        try:
+            if error:
+                QMessageBox.critical(self, "Git", msg)
+            else:
+                QMessageBox.information(self, "Git", msg)
+        except Exception:
+            self._dbg(f"ALERT: {msg}")
 
-        self.lblScope = QLabel("Acciones aplican a TODOS los módulos del proyecto actual."); top.addWidget(self.lblScope, row, 0, 1, 4); row += 1
+    def _setup_ui(self):
+        root = QVBoxLayout(self)
+        root.setContentsMargins(8, 8, 8, 8)
+        root.setSpacing(8)
+
+        tabs = QTabWidget()
+        root.addWidget(tabs, 1)
+
+        main = QWidget()
+        tabs.addTab(main, "Repos Git")
+        top_wrap = QVBoxLayout(main)
+
+        proj = QGridLayout()
+        proj.setHorizontalSpacing(8)
+        proj.setVerticalSpacing(6)
+        row = 0
+        proj.addWidget(QLabel("Proyecto:"), row, 0)
+        self.cboProject = QComboBox(); proj.addWidget(self.cboProject, row, 1); row += 1
+
+        self.lblScope = QLabel("Acciones aplican a TODOS los módulos del proyecto actual."); proj.addWidget(self.lblScope, row, 0, 1, 4); row += 1
+        self.lblCurrent = QLabel("Rama actual: ?"); proj.addWidget(self.lblCurrent, row, 0, 1, 4); row += 1
+        top_wrap.addLayout(proj)
+
+        ops = QGroupBox("Acciones de ramas")
+        opsl = QVBoxLayout(ops)
 
         self.cboHistorySwitch = QComboBox(); self.cboHistorySwitch.setEditable(True)
         self.btnSwitch = QPushButton("Switch (global)")
         hs = QHBoxLayout(); hs.addWidget(QLabel("Rama:")); hs.addWidget(self.cboHistorySwitch, 1); hs.addWidget(self.btnSwitch)
-        top.addLayout(hs, row, 0, 1, 4); row += 1
+        opsl.addLayout(hs)
 
         self.txtNewBranch = QLineEdit(); self.txtNewBranch.setPlaceholderText("Nombre de la nueva rama")
         self.btnCreateLocal = QPushButton("Crear rama (local, global)"); self.btnPushBranch = QPushButton("Push rama (global)")
         hnew = QHBoxLayout(); hnew.addWidget(QLabel("Nueva rama:")); hnew.addWidget(self.txtNewBranch, 1); hnew.addWidget(self.btnCreateLocal); hnew.addWidget(self.btnPushBranch)
-        top.addLayout(hnew, row, 0, 1, 4); row += 1
+        opsl.addLayout(hnew)
 
         self.cboDeleteBranch = QComboBox(); self.cboDeleteBranch.setEditable(True)
         self.chkConfirmDelete = QCheckBox("Confirmar")
         self.btnDeleteBranch = QPushButton("Eliminar rama local (global)")
         hd = QHBoxLayout(); hd.addWidget(QLabel("Eliminar:")); hd.addWidget(self.cboDeleteBranch, 1); hd.addWidget(self.chkConfirmDelete); hd.addWidget(self.btnDeleteBranch)
-        top.addLayout(hd, row, 0, 1, 4); row += 1
+        opsl.addLayout(hd)
 
         self.txtVersion = QLineEdit(); self.txtVersion.setPlaceholderText("3.00.17")
         self.chkQA = QCheckBox("Crear *_QA"); self.btnRunCreateVersion = QPushButton("Crear ramas de versión (local, global)")
         hv = QHBoxLayout(); hv.addWidget(QLabel("Versión:")); hv.addWidget(self.txtVersion, 1); hv.addWidget(self.chkQA); hv.addWidget(self.btnRunCreateVersion)
-        top.addLayout(hv, row, 0, 1, 4); row += 1
+        opsl.addLayout(hv)
 
         self.btnRefresh = QPushButton("Refrescar vista"); self.btnReconcile = QPushButton("Reconciliar con Git (solo local)")
-        hr = QHBoxLayout(); hr.addWidget(self.btnRefresh); hr.addStretch(); hr.addWidget(self.btnReconcile)
-        top.addLayout(hr, row, 0, 1, 4); row += 1
+        self.btnNasRecover = QPushButton("Recuperar NAS"); self.btnNasPublish = QPushButton("Publicar NAS")
+        hr = QHBoxLayout(); hr.addWidget(self.btnRefresh); hr.addWidget(self.btnNasRecover); hr.addWidget(self.btnNasPublish); hr.addStretch(); hr.addWidget(self.btnReconcile)
+        opsl.addLayout(hr)
 
-        gr = QGroupBox("Resumen de ramas (cache/local)")
+        top_wrap.addWidget(ops)
+
+        gr = QGroupBox("Módulos y ramas actuales")
         grl = QVBoxLayout(gr)
         self.tree = QTreeWidget(); self.tree.setHeaderLabels(["Módulo", "Rama", "Estado", "Actual"])
         self.tree.setRootIsDecorated(False); self.tree.setAlternatingRowColors(True)
         grl.addWidget(self.tree, 1)
-        top.addWidget(gr, row, 0, 1, 4); row += 1
+        top_wrap.addWidget(gr)
 
-        root.addLayout(top)
-        self.log = QTextEdit(); self.log.setReadOnly(True); self.log.setLineWrapMode(QTextEdit.NoWrap)
-        root.addWidget(self.log, 1)
-        self.logger = Logger(); self.logger.line.connect(self.log.append)
+        grh = QGroupBox("Historial de ramas")
+        grhl = QVBoxLayout(grh)
+        self.treeHist = QTreeWidget()
+        self.treeHist.setHeaderLabels(["Rama", "Usuario", "Creación", "Local", "Origin", "Merge"])
+        self.treeHist.setRootIsDecorated(False)
+        self.treeHist.setAlternatingRowColors(True)
+        grhl.addWidget(self.treeHist, 1)
+        top_wrap.addWidget(grh)
+
+        console = QWidget()
+        tabs.addTab(console, "Consola")
+        clog_layout = QVBoxLayout(console)
+        self.log = QTextEdit()
+        self.log.setReadOnly(True)
+        self.log.setLineWrapMode(QTextEdit.NoWrap)
+        clog_layout.addWidget(self.log, 1)
+        self.btnClearLog = QPushButton("Limpiar")
+        hcl = QHBoxLayout()
+        hcl.addStretch()
+        hcl.addWidget(self.btnClearLog)
+        clog_layout.addLayout(hcl)
+
+        self.logger = Logger()
+        self.logger.line.connect(self.log.append)
 
     def _wire_events(self):
         self.cboProject.currentTextChanged.connect(self._on_project_changed)
@@ -138,7 +205,9 @@ class GitView(QWidget):
         self.btnPushBranch.clicked.connect(self._do_push_branch)
         self.btnDeleteBranch.clicked.connect(self._do_delete_branch)
         self.btnRunCreateVersion.clicked.connect(self._do_create_version)
-        self.btnRefresh.clicked.connect(self._post_project_change)
+        self.btnNasRecover.clicked.connect(self._do_recover_nas)
+        self.btnNasPublish.clicked.connect(self._do_publish_nas)
+        self.btnClearLog.clicked.connect(self.log.clear)
 
 
     def _load_projects_flat(self):
@@ -233,6 +302,7 @@ class GitView(QWidget):
                     self._dbg(f"post_project_change: HERR_REPO(groups.repos)={os.environ['HERR_REPO']}")
                     self._refresh_history()
                     self._refresh_summary()
+                    self._refresh_branch_index()
                     self._dbg("post_project_change: end")
                     return
             except Exception as e:
@@ -241,6 +311,7 @@ class GitView(QWidget):
             # Si llegaste aquí, no hay workspace para gkey; aún así refresca UI
             self._refresh_history()
             self._refresh_summary()
+            self._refresh_branch_index()
         except Exception as e:
             self._dbg(f"post_project_change: ERROR {e}")
         self._dbg("post_project_change: end")
@@ -257,10 +328,12 @@ class GitView(QWidget):
             b2 = QtCore.QSignalBlocker(self.cboDeleteBranch)
             self.cboHistorySwitch.clear(); self.cboDeleteBranch.clear()
             gkey, pkey = self._current_keys()
-            hist = STATE.get_history(gkey, pkey) or []
-            for br in hist[:50]:
-                self.cboHistorySwitch.addItem(br)
-                self.cboDeleteBranch.addItem(br)
+            idx = load_index()
+            records = [r for r in idx.values() if r.group == gkey and r.project == pkey]
+            records.sort(key=lambda r: r.last_updated_at, reverse=True)
+            for rec in records[:50]:
+                self.cboHistorySwitch.addItem(rec.branch)
+                self.cboDeleteBranch.addItem(rec.branch)
             self._dbg("_refresh_history: loaded")
         except Exception as e:
             self._dbg(f"_refresh_history: ERROR {e}")
@@ -275,9 +348,13 @@ class GitView(QWidget):
 
             gkey, pkey = self._current_keys()
             items = discover_status_fast(self.cfg, gkey, pkey) or []
+            proj_current = None
             for name, br, path in items:
                 locals_, remotes_ = STATE.get_presence(gkey, pkey, name)
-                current = STATE.get_current(gkey, pkey, name) or br or "?"
+                current = get_current_branch_fast(path) or br or "?"
+                STATE.set_current(gkey, pkey, name, current)
+                if proj_current is None:
+                    proj_current = current
                 branches = sorted(set(locals_) | set(remotes_) | ({current} if current else set()))
                 if not branches:
                     branches = [current]
@@ -288,6 +365,7 @@ class GitView(QWidget):
                     it = QtWidgets.QTreeWidgetItem([name, b, estado, curflag])
                     self.tree.addTopLevelItem(it)
 
+            self.lblCurrent.setText(f"Rama actual: {proj_current or '?'}")
             self.tree.resizeColumnToContents(0)
             self.tree.resizeColumnToContents(1)
             self.tree.resizeColumnToContents(2)
@@ -298,17 +376,48 @@ class GitView(QWidget):
             if _is_valid_qobj(self.tree):
                 self.tree.setUpdatesEnabled(True)
 
+    def _refresh_branch_index(self):
+        self._dbg("_refresh_branch_index: start")
+        if not _is_valid_qobj(self) or not _is_valid_qobj(getattr(self, "treeHist", None)):
+            return
+        try:
+            self.treeHist.setUpdatesEnabled(False)
+            self.treeHist.clear()
+            gkey, pkey = self._current_keys()
+            idx = load_index()
+            records = [r for r in idx.values() if r.group == gkey and r.project == pkey]
+            records.sort(key=lambda r: r.last_updated_at, reverse=True)
+            for rec in records:
+                loc = "Sí" if rec.exists_local else ""
+                orig = "Sí" if rec.exists_origin else ""
+                fecha = ""
+                if rec.created_at:
+                    fecha = datetime.fromtimestamp(rec.created_at).strftime("%Y-%m-%d %H:%M")
+                it = QtWidgets.QTreeWidgetItem(
+                    [rec.branch, rec.created_by, fecha, loc, orig, rec.merge_status]
+                )
+                self.treeHist.addTopLevelItem(it)
+            self.treeHist.resizeColumnToContents(0)
+            self.treeHist.resizeColumnToContents(1)
+            self.treeHist.resizeColumnToContents(2)
+        except Exception as e:
+            self._dbg(f"_refresh_branch_index: ERROR {e}")
+        finally:
+            if _is_valid_qobj(self.treeHist):
+                self.treeHist.setUpdatesEnabled(True)
+
     # en buildtool/views/git_view.py (dentro de GitView)
     def _init_thread_store(self):
         if not hasattr(self, "_live_threads"):
             self._live_threads = set()
 
-    def _start_task(self, title, fn, done_cb=None, *args, **kwargs):
+    def _start_task(self, title, fn, done_cb=None, *args, success: str | None = None, error: str | None = None, **kwargs):
         self._dbg(f"task start: {title}")
         th, worker = run_in_thread(fn, *args, **kwargs)
 
-        # Si quieres conservar un callback de "done":
         self._pending_done_cb = done_cb
+        self._pending_success = success
+        self._pending_error = error
 
         # Señales (no toques UI aquí; sólo enruta a la UI con el slot)
         worker.progress.connect(self.logger.line.emit)
@@ -345,19 +454,23 @@ class GitView(QWidget):
         """Este slot SIEMPRE corre en el hilo de la UI (QueuedConnection)."""
         try:
             self._dbg(f"task end (slot): ok={ok}")
-            # Toca UI sólo aquí (hilo principal):
             self._refresh_history()
             self._refresh_summary()
-            # Si tu _start_task quiere permitir callbacks externos:
+            self._refresh_branch_index()
             cb = getattr(self, "_pending_done_cb", None)
             if cb:
                 try:
                     cb(ok)
                 finally:
                     self._pending_done_cb = None
+            msg = self._pending_success if ok else self._pending_error
+            if msg:
+                self._alert(msg, error=not ok)
         except Exception as e:
             errguard.log(f"_on_task_finish error: {e}", level=40)
-
+        finally:
+            self._pending_success = None
+            self._pending_error = None
 
     def _set_task_buttons_enabled(self, enabled: bool):
         for btn in (self.btnCreateLocal, self.btnPushBranch, self.btnDeleteBranch, self.btnSwitch):
@@ -369,22 +482,26 @@ class GitView(QWidget):
     def _do_switch(self):
         branch = self.cboHistorySwitch.currentText().strip()
         if not branch:
-            self._dbg("_do_switch: empty"); return
+            self._alert("Especifica una rama", error=True); return
         gkey, pkey = self._current_keys()
         def _after():
             for name, _, _ in discover_status_fast(self.cfg, gkey, pkey):
                 STATE.set_current(gkey, pkey, name, branch)
             STATE.add_history(gkey, pkey, branch)
-        self._start_task(f"Switch a {branch} (global)",
+        self._start_task(
+            f"Switch a {branch} (global)",
             lambda cfg, gk, pk, br, emit=self.logger.line.emit: switch_branch(cfg, gk, pk, br, emit, only_modules=None),
-            _after, self.cfg, gkey, pkey, branch)
+            _after, self.cfg, gkey, pkey, branch,
+            success=f"Cambiaste a {branch}",
+            error=f"No se pudo cambiar a {branch}"
+        )
 
     @safe_slot
     def _do_create_local(self):
         gkey, pkey = self._current_keys()
         name = self.txtNewBranch.text().strip()
         if not name:
-            self._dbg("_do_create_local: empty"); return
+            self._alert("Indica el nombre de la rama", error=True); return
         
         def task(cfg, gk, pk, br, emit=self.logger.line.emit):
             emit(f"[task] Crear rama local '{br}' (global)")
@@ -392,42 +509,55 @@ class GitView(QWidget):
             emit("[task] DONE" if ok else "[task] DONE with errors")
             return ok
 
-        self._start_task(f"Crear rama local {name} (global)", task, None, self.cfg, gkey, pkey, name)
+        self._start_task(
+            f"Crear rama local {name} (global)",
+            task, None, self.cfg, gkey, pkey, name,
+            success=f"Rama {name} creada",
+            error=f"No se pudo crear {name}"
+        )
 
 
     @safe_slot
     def _do_push_branch(self):
         nb = self.txtNewBranch.text().strip() or self.cboHistorySwitch.currentText().strip()
         if not nb:
-            self._dbg("_do_push_branch: empty"); return
+            self._alert("Indica la rama a enviar", error=True); return
         gkey, pkey = self._current_keys()
         def _after():
             for name, _, _ in discover_status_fast(self.cfg, gkey, pkey):
                 STATE.add_remote(gkey, pkey, name, nb)
-        self._start_task(f"Push rama {nb} (global)",
+        self._start_task(
+            f"Push rama {nb} (global)",
             lambda cfg, gk, pk, name, emit=self.logger.line.emit: push_branch(cfg, gk, pk, name, emit, only_modules=None),
-            _after, self.cfg, gkey, pkey, nb)
+            _after, self.cfg, gkey, pkey, nb,
+            success=f"Rama {nb} enviada a origin",
+            error=f"No se pudo enviar {nb}"
+        )
 
     @safe_slot
     def _do_delete_branch(self):
         nb = self.cboDeleteBranch.currentText().strip()
         if not nb:
-            self._dbg("_do_delete_branch: empty"); return
+            self._alert("Indica la rama a eliminar", error=True); return
         if not self.chkConfirmDelete.isChecked():
-            self._dbg("_do_delete_branch: confirmar"); return
+            self._alert("Confirma la eliminación", error=True); return
         gkey, pkey = self._current_keys()
         def _after():
             for name, _, _ in discover_status_fast(self.cfg, gkey, pkey):
                 STATE.remove_local(gkey, pkey, name, nb)
-        self._start_task(f"Eliminar rama local {nb} (global)",
+        self._start_task(
+            f"Eliminar rama local {nb} (global)",
             lambda cfg, gk, pk, name, confirm, emit=self.logger.line.emit: delete_local_branch_by_name(cfg, gk, pk, name, confirm, emit, only_modules=None),
-            _after, self.cfg, gkey, pkey, nb, True)
+            _after, self.cfg, gkey, pkey, nb, True,
+            success=f"Rama {nb} eliminada",
+            error=f"No se pudo eliminar {nb}"
+        )
 
     @safe_slot
     def _do_create_version(self):
         ver = self.txtVersion.text().strip()
         if not ver:
-            self._dbg("_do_create_version: empty"); return
+            self._alert("Indica la versión", error=True); return
         create_qa = self.chkQA.isChecked()
         gkey, pkey = self._current_keys()
         def _after():
@@ -440,9 +570,13 @@ class GitView(QWidget):
             STATE.add_history(gkey, pkey, ver)
             if create_qa:
                 STATE.add_history(gkey, pkey, f"{ver}_QA")
-        self._start_task(f"Crear ramas versión {ver} (global)",
+        self._start_task(
+            f"Crear ramas versión {ver} (global)",
             lambda cfg, gk, pk, v, qa, emit=self.logger.line.emit: create_version_branches(cfg, gk, pk, v, qa, {}, [], emit, only_modules=None),
-            _after, self.cfg, gkey, pkey, ver, create_qa)
+            _after, self.cfg, gkey, pkey, ver, create_qa,
+            success=f"Ramas {ver} creadas",
+            error=f"No se pudieron crear ramas {ver}"
+        )
 
     @safe_slot
     def _do_reconcile(self):
@@ -457,4 +591,28 @@ class GitView(QWidget):
                 for b in list_local_branches_fast(path):
                     STATE.add_local(gk, pk, name, b)
             return True
-        self._start_task("Reconciliar con Git (local)", reconcile_task, None, self.cfg, gkey, pkey)
+        self._start_task(
+            "Reconciliar con Git (local)", reconcile_task, None, self.cfg, gkey, pkey,
+            success="Reconciliación completa",
+            error="Error al reconciliar"
+        )
+
+    @safe_slot
+    def _do_recover_nas(self):
+        def task():
+            emit = self.logger.line.emit
+            emit("[task] Recuperar NAS")
+            recover_from_nas()
+            emit("[task] DONE")
+            return True
+        self._start_task("Recuperar NAS", task, success="Historial recuperado de NAS", error="Error al recuperar NAS")
+
+    @safe_slot
+    def _do_publish_nas(self):
+        def task():
+            emit = self.logger.line.emit
+            emit("[task] Publicar NAS")
+            publish_to_nas()
+            emit("[task] DONE")
+            return True
+        self._start_task("Publicar NAS", task, success="Historial publicado en NAS", error="Error al publicar NAS")


### PR DESCRIPTION
## Summary
- show shared branch history and statuses within Git view
- add buttons to recover and publish branch index to NAS
- populate branch selectors from centralized branch index
- restrict NAS sync to branches already pushed to origin
- display branch creator and rename project summary section
- move console output to a dedicated tab with a clear button
- indicate current branch per project and show creation timestamps
- pop up alerts on success or failure of git operations

## Testing
- `python -m py_compile buildtool/views/git_view.py buildtool/core/git_tasks_local.py buildtool/core/branch_store.py`


------
https://chatgpt.com/codex/tasks/task_e_68c756fc3c64832cb0e2739ef6850b13