### PR TITLE
Fix NAS recovery when NAS index has unexpected fields

### DIFF
--- a/buildtool/tests/test_branch_store.py
+++ b/buildtool/tests/test_branch_store.py
@@ -1,0 +1,65 @@
+import json
+import tempfile
+from pathlib import Path
+import unittest
+
+from buildtool.core.branch_store import load_index
+
+
+class LoadIndexTest(unittest.TestCase):
+
+    def _write_index(self, base: Path, payload: dict) -> Path:
+        path = base / "branches_index.json"
+        path.write_text(json.dumps(payload), encoding="utf-8")
+        return path
+
+    def test_load_index_ignores_unknown_fields(self):
+        payload = {
+            "version": 1,
+            "items": [
+                {
+                    "branch": "feature/x",
+                    "group": "g",
+                    "project": "p",
+                    "exists_origin": True,
+                    "exists_local": False,
+                    "extra": "ignore-me",
+                }
+            ],
+        }
+        with tempfile.TemporaryDirectory() as td:
+            base = Path(td)
+            path = self._write_index(base, payload)
+            index = load_index(path)
+        self.assertIn("g/p/feature/x", index)
+
+    def test_load_index_accepts_legacy_names_and_types(self):
+        payload = {
+            "version": 1,
+            "items": [
+                {
+                    "branch": "feature/y",
+                    "group": "g",
+                    "project": "p",
+                    "exists_origin": "yes",
+                    "exists_local": "no",
+                    "last_update": "1700000000",
+                    "last_update_by": "alice",
+                }
+            ],
+        }
+        with tempfile.TemporaryDirectory() as td:
+            base = Path(td)
+            path = self._write_index(base, payload)
+            index = load_index(path)
+        rec = index.get("g/p/feature/y")
+        self.assertIsNotNone(rec)
+        if rec:
+            self.assertTrue(rec.exists_origin)
+            self.assertFalse(rec.exists_local)
+            self.assertEqual(rec.last_updated_at, 1700000000)
+            self.assertEqual(rec.last_updated_by, "alice")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- normalize NAS branch record payloads before instantiating `BranchRecord` so unknown keys and legacy names are tolerated
- coerce string boolean/integer values and support legacy timestamp keys when loading the branch index
- add regression tests that cover the legacy payload shapes to ensure future compatibility

## Testing
- python -m unittest

------
https://chatgpt.com/codex/tasks/task_e_68c857271fa0832cb6d09eab8d314e28