### PR TITLE
Improve Windows maven runs and parallel profile scheduling

### DIFF
--- a/buildtool/core/maven.py
+++ b/buildtool/core/maven.py
@@ -12,8 +12,11 @@ def run_maven(module_path: str, goals, profile: str|None=None, env: dict|None=No
     log_cb("$ " + " ".join(shlex.quote(x) for x in mvn_cmd))
 
     creationflags = 0
-    if separate_window and os.name == "nt":
-        creationflags = getattr(subprocess, "CREATE_NEW_CONSOLE", 0)
+    if os.name == "nt":
+        if separate_window:
+            creationflags = getattr(subprocess, "CREATE_NEW_CONSOLE", 0)
+        else:
+            creationflags = getattr(subprocess, "CREATE_NO_WINDOW", 0)
 
     proc = subprocess.Popen(
         mvn_cmd,


### PR DESCRIPTION
## Summary
- hide the extra Windows consoles when Maven runs in integrated logging mode
- reschedule build tasks so modules across profiles can execute in parallel while respecting serial locks

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cc8e17b138832c9cd84700caade66b