### PR TITLE
Refactor Git history views and track branch state per user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ Todas las versiones notables de ForgeBuild (Grupos) se documentarán en este arc
 
 El formato sigue, en líneas generales, las recomendaciones de [Keep a Changelog](https://keepachangelog.com/es-ES/1.1.0/).
 
+## [Unreleased]
+### Añadido
+- Tabla `branch_local_users` en SQL Server para registrar la presencia local de cada rama por usuario y exponerla mediante `load_local_states` y nuevas pruebas automatizadas.
+
+### Cambiado
+- `BranchHistoryView` y la pestaña Git muestran un único historial respaldado por SQL Server, eliminando los flujos de sincronización NAS y adoptando el registro de actividad renombrado.
+- `BranchRecord` ahora calcula la disponibilidad local por usuario activo, propagando la información al backend al guardar o sincronizar el índice.
+
 ## [1.6.0] - 2025-02-15
 ### Añadido
 - Capa de persistencia extensible para el historial de ramas con soporte a SQL Server 2019 mediante `BranchHistoryRepo`.

--- a/buildtool/core/branch_history_db.py
+++ b/buildtool/core/branch_history_db.py
@@ -571,6 +571,20 @@ class _SqlServerBranchHistory:
             END
             """,
             """
+            IF NOT EXISTS (SELECT 1 FROM sys.tables WHERE name = 'branch_local_users')
+            BEGIN
+                CREATE TABLE branch_local_users (
+                    branch_key NVARCHAR(512) NOT NULL,
+                    username NVARCHAR(255) NOT NULL,
+                    state NVARCHAR(32) NOT NULL DEFAULT 'absent',
+                    location NVARCHAR(1024) NULL,
+                    updated_at BIGINT NOT NULL DEFAULT 0,
+                    CONSTRAINT pk_branch_local_users PRIMARY KEY (branch_key, username),
+                    CONSTRAINT fk_branch_local_users_branch FOREIGN KEY (branch_key) REFERENCES branches([key]) ON DELETE CASCADE
+                );
+            END
+            """,
+            """
             IF NOT EXISTS (
                 SELECT name FROM sys.indexes WHERE name = 'idx_activity_branch_key'
                     AND object_id = OBJECT_ID('activity_log')
@@ -613,6 +627,24 @@ class _SqlServerBranchHistory:
             )
             BEGIN
                 CREATE INDEX idx_cards_branch ON cards(branch);
+            END
+            """,
+            """
+            IF NOT EXISTS (
+                SELECT name FROM sys.indexes WHERE name = 'idx_branch_local_users_username'
+                    AND object_id = OBJECT_ID('branch_local_users')
+            )
+            BEGIN
+                CREATE INDEX idx_branch_local_users_username ON branch_local_users(username);
+            END
+            """,
+            """
+            IF NOT EXISTS (
+                SELECT name FROM sys.indexes WHERE name = 'idx_branch_local_users_state'
+                    AND object_id = OBJECT_ID('branch_local_users')
+            )
+            BEGIN
+                CREATE INDEX idx_branch_local_users_state ON branch_local_users(state);
             END
             """,
         ]
@@ -681,6 +713,42 @@ class _SqlServerBranchHistory:
                 data.get("last_action"),
                 data.get("last_updated_at"),
                 data.get("last_updated_by"),
+            ),
+        )
+
+    def _execute_upsert_branch_local_user(
+        self,
+        cursor: "pymssql.Cursor",
+        data: Dict[str, object],
+    ) -> None:
+        update_sql = """
+            UPDATE branch_local_users
+               SET state=%s, location=%s, updated_at=%s
+             WHERE branch_key=%s AND username=%s
+        """
+        params = (
+            data.get("state"),
+            data.get("location"),
+            data.get("updated_at"),
+            data.get("branch_key"),
+            data.get("username"),
+        )
+        cursor.execute(update_sql, params)
+        if cursor.rowcount:
+            return
+        insert_sql = """
+            INSERT INTO branch_local_users (
+                branch_key, username, state, location, updated_at
+            ) VALUES (%s, %s, %s, %s, %s)
+        """
+        cursor.execute(
+            insert_sql,
+            (
+                data.get("branch_key"),
+                data.get("username"),
+                data.get("state"),
+                data.get("location"),
+                data.get("updated_at"),
             ),
         )
 
@@ -777,16 +845,91 @@ class _SqlServerBranchHistory:
             cursor = conn.cursor()
             cursor.execute("DELETE FROM branches WHERE [key]=%s", (key,))
 
-    def fetch_branches(self, *, filter_origin: bool = False) -> List[dict]:
-        sql = "SELECT [key], branch, group_name, project, created_at, created_by, exists_local, exists_origin, merge_status, diverged, stale_days, last_action, last_updated_at, last_updated_by FROM branches"
+    def fetch_branches(
+        self,
+        *,
+        filter_origin: bool = False,
+        username: Optional[str] = None,
+    ) -> List[dict]:
+        sql = (
+            "SELECT b.[key], b.branch, b.group_name, b.project, b.created_at, b.created_by,"
+            " b.exists_local, b.exists_origin, b.merge_status, b.diverged, b.stale_days,"
+            " b.last_action, b.last_updated_at, b.last_updated_by,"
+            " u.state AS local_state, u.location AS local_location, u.updated_at AS local_updated_at"
+            " FROM branches AS b"
+        )
+        params: List[object] = []
+        if username:
+            sql += " LEFT JOIN branch_local_users AS u ON u.branch_key = b.[key] AND u.username = %s"
+            params.append(username)
+        else:
+            sql += " LEFT JOIN branch_local_users AS u ON u.branch_key = b.[key]"
+        where_clauses: List[str] = []
         if filter_origin:
-            sql += " WHERE exists_origin = 1"
-        sql += " ORDER BY last_updated_at DESC, [key]"
+            where_clauses.append("b.exists_origin = 1")
+        if where_clauses:
+            sql += " WHERE " + " AND ".join(where_clauses)
+        sql += " ORDER BY b.last_updated_at DESC, b.[key]"
         with self._connect() as conn:
             cursor = conn.cursor()
-            cursor.execute(sql)
+            cursor.execute(sql, tuple(params))
             rows = cursor.fetchall()
         return [dict(row) for row in rows]
+
+    def fetch_branch_local_users(
+        self,
+        *,
+        branch_keys: Optional[Sequence[str]] = None,
+        username: Optional[str] = None,
+    ) -> List[dict]:
+        sql = (
+            "SELECT branch_key, username, state, location, updated_at"
+            " FROM branch_local_users"
+        )
+        params: List[object] = []
+        conditions: List[str] = []
+        keys = [key for key in (branch_keys or []) if key]
+        if keys:
+            placeholders = ",".join("%s" for _ in keys)
+            conditions.append(f"branch_key IN ({placeholders})")
+            params.extend(keys)
+        if username:
+            conditions.append("username=%s")
+            params.append(username)
+        if conditions:
+            sql += " WHERE " + " AND ".join(conditions)
+        with self._connect() as conn:
+            cursor = conn.cursor()
+            cursor.execute(sql, tuple(params))
+            rows = cursor.fetchall()
+        return [dict(row) for row in rows]
+
+    def upsert_branch_local_user(
+        self,
+        branch_key: str,
+        username: str,
+        state: str,
+        location: Optional[str],
+        updated_at: int,
+    ) -> None:
+        data = {
+            "branch_key": branch_key,
+            "username": username,
+            "state": state,
+            "location": location,
+            "updated_at": updated_at,
+        }
+        with self._connect() as conn:
+            cursor = conn.cursor()
+            self._execute_upsert_branch_local_user(cursor, data)
+
+    def delete_branch_local_user(self, branch_key: str, username: str) -> None:
+        with self._connect() as conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                "DELETE FROM branch_local_users WHERE branch_key=%s AND username=%s",
+                (branch_key, username),
+            )
 
     def fetch_activity(self, *, branch_keys: Optional[Iterable[str]] = None) -> List[dict]:
         sql = "SELECT ts, [user] AS [user], group_name, project, branch, action, result, message, branch_key FROM activity_log"

--- a/buildtool/core/git_tasks_local.py
+++ b/buildtool/core/git_tasks_local.py
@@ -455,7 +455,7 @@ def create_branches_local(
     if ok_all:
         idx = load_index()
         rec = _get_record(idx, gkey, pkey, bname)
-        rec.exists_local = True
+        rec.mark_local(True)
         rec.last_action = "create_local"
         rec.last_updated_by = _current_user()
         upsert(rec, idx, action="create_local")
@@ -571,14 +571,14 @@ def create_version_branches(
     if ok_base:
         idx = load_index()
         rec = _get_record(idx, gkey, pkey, branch_base)
-        rec.exists_local = True
+        rec.mark_local(True)
         rec.last_action = "create_local"
         rec.last_updated_by = _current_user()
         upsert(rec, idx, action="create_local")
     if create_qa and ok_base and ok_qa:
         idx = load_index()
         rec = _get_record(idx, gkey, pkey, branch_qa)
-        rec.exists_local = True
+        rec.mark_local(True)
         rec.last_action = "create_local"
         rec.last_updated_by = _current_user()
         upsert(rec, idx, action="create_local")
@@ -647,7 +647,7 @@ def switch_branch(
     if ok_all:
         idx = load_index()
         rec = _get_record(idx, gkey, pkey, bname)
-        rec.exists_local = True
+        rec.mark_local(True)
         rec.last_action = "switch"
         rec.last_updated_by = _current_user()
         upsert(rec, idx, action="switch")
@@ -708,7 +708,7 @@ def delete_local_branch_by_name(
     if exists_origin:
         if not rec:
             rec = BranchRecord(branch=bname, group=gkey, project=pkey, created_by=_current_user())
-        rec.exists_local = exists_local
+        rec.mark_local(exists_local)
         rec.exists_origin = True
         rec.last_action = "delete_local" if not exists_local else rec.last_action
         rec.last_updated_by = _current_user()
@@ -753,7 +753,7 @@ def push_branch(
 
     idx = load_index()
     rec = _get_record(idx, gkey, pkey, bname)
-    rec.exists_local = True
+    rec.mark_local(True)
     rec.exists_origin = exists_origin
     rec.last_action = "push_origin" if ok_all else "push_failed"
     rec.last_updated_by = _current_user()

--- a/buildtool/tests/test_branch_store.py
+++ b/buildtool/tests/test_branch_store.py
@@ -17,6 +17,7 @@ from buildtool.core.branch_store import (
 class FakeBranchHistory:
     def __init__(self) -> None:
         self.branch_rows: dict[str, dict] = {}
+        self.branch_local_users: dict[tuple[str, str], dict] = {}
         self.activity_rows: list[dict] = []
         self.sprints: dict[int, dict] = {}
         self.cards: dict[int, dict] = {}
@@ -27,11 +28,25 @@ class FakeBranchHistory:
         self.next_card_id = 1
 
     # Branches ---------------------------------------------------------
-    def fetch_branches(self, filter_origin: bool = False) -> list[dict]:
-        rows = list(self.branch_rows.values())
-        if filter_origin:
-            rows = [row for row in rows if row.get("exists_origin")]
-        return [row.copy() for row in rows]
+    def fetch_branches(self, filter_origin: bool = False, username: str | None = None) -> list[dict]:
+        rows: list[dict] = []
+        for row in self.branch_rows.values():
+            if filter_origin and not row.get("exists_origin"):
+                continue
+            data = row.copy()
+            entry = None
+            if username:
+                entry = self.branch_local_users.get((row.get("key"), username))
+            if entry:
+                data["local_state"] = entry.get("state")
+                data["local_location"] = entry.get("location")
+                data["local_updated_at"] = entry.get("updated_at")
+            else:
+                data["local_state"] = None
+                data["local_location"] = None
+                data["local_updated_at"] = None
+            rows.append(data)
+        return rows
 
     def replace_branches(self, records: list[dict]) -> None:
         self.branch_rows = {rec["key"]: rec.copy() for rec in records}
@@ -41,6 +56,44 @@ class FakeBranchHistory:
 
     def delete_branch(self, key: str) -> None:
         self.branch_rows.pop(key, None)
+        to_remove = [entry for entry in self.branch_local_users if entry[0] == key]
+        for entry in to_remove:
+            self.branch_local_users.pop(entry, None)
+
+    def fetch_branch_local_users(
+        self,
+        branch_keys: list[str] | None = None,
+        username: str | None = None,
+    ) -> list[dict]:
+        results: list[dict] = []
+        keys = set(branch_keys or []) if branch_keys else None
+        for (branch_key, user), payload in self.branch_local_users.items():
+            if keys and branch_key not in keys:
+                continue
+            if username and user != username:
+                continue
+            entry = payload.copy()
+            entry["branch_key"] = branch_key
+            entry["username"] = user
+            results.append(entry)
+        return results
+
+    def upsert_branch_local_user(
+        self,
+        branch_key: str,
+        username: str,
+        state: str,
+        location: str | None,
+        updated_at: int,
+    ) -> None:
+        self.branch_local_users[(branch_key, username)] = {
+            "state": state,
+            "location": location,
+            "updated_at": updated_at,
+        }
+
+    def delete_branch_local_user(self, branch_key: str, username: str) -> None:
+        self.branch_local_users.pop((branch_key, username), None)
 
     # Activity ---------------------------------------------------------
     def append_activity(self, entries: list[dict]) -> None:
@@ -167,8 +220,10 @@ class BranchStoreSqlServerTest(unittest.TestCase):
         self.tmp = tempfile.TemporaryDirectory()
         self.old_appdata = os.environ.get("APPDATA")
         self.old_xdg = os.environ.get("XDG_DATA_HOME")
+        self.old_username = os.environ.get("USERNAME")
         os.environ["APPDATA"] = self.tmp.name
         os.environ["XDG_DATA_HOME"] = self.tmp.name
+        os.environ["USERNAME"] = "alice"
         self.fake = FakeBranchHistory()
         branch_store._DB_CACHE.clear()
         branch_store._DB_CACHE[branch_store._SERVER_CACHE_KEY] = self.fake
@@ -184,6 +239,10 @@ class BranchStoreSqlServerTest(unittest.TestCase):
             os.environ.pop("XDG_DATA_HOME", None)
         else:
             os.environ["XDG_DATA_HOME"] = self.old_xdg
+        if self.old_username is None:
+            os.environ.pop("USERNAME", None)
+        else:
+            os.environ["USERNAME"] = self.old_username
         self.tmp.cleanup()
 
     def test_load_index_normalizes_fields(self) -> None:
@@ -209,7 +268,7 @@ class BranchStoreSqlServerTest(unittest.TestCase):
         rec = index["g/p/feature/x"]
         self.assertEqual(rec.branch, "feature/x")
         self.assertEqual(rec.group, "g")
-        self.assertFalse(rec.exists_local)
+        self.assertFalse(rec.has_local_copy())
         self.assertTrue(rec.exists_origin)
         self.assertEqual(rec.stale_days, 5)
         self.assertEqual(rec.last_updated_at, 1700000001)
@@ -220,8 +279,8 @@ class BranchStoreSqlServerTest(unittest.TestCase):
             group="g",
             project="p",
             created_by="alice",
-            exists_local=True,
         )
+        rec.mark_local(True)
         branch_store.record_activity("create", rec)
         self.assertEqual(len(self.fake.activity_rows), 1)
         stored = self.fake.activity_rows[0]
@@ -245,6 +304,35 @@ class BranchStoreSqlServerTest(unittest.TestCase):
         self.assertEqual(len(entries), 1)
         self.assertEqual(entries[0]["user"], "bob")
         self.assertEqual(entries[0]["action"], "create")
+
+    def test_upsert_registers_local_user_state(self) -> None:
+        rec = BranchRecord(branch="feature/state", group="g", project="p", created_by="alice")
+        rec.mark_local(True)
+        branch_store.upsert(rec, action="test")
+
+        entry = self.fake.branch_local_users.get(("g/p/feature/state", "alice"))
+        self.assertIsNotNone(entry)
+        assert entry  # for type checker
+        self.assertEqual(entry["state"], "present")
+        self.assertGreater(entry["updated_at"], 0)
+
+    def test_save_index_synchronizes_local_states(self) -> None:
+        rec_a = BranchRecord(branch="feature/a", group="g", project="p", created_by="alice")
+        rec_a.mark_local(True)
+        rec_b = BranchRecord(branch="feature/b", group="g", project="p", created_by="alice")
+        rec_b.mark_local(False)
+        index = {
+            rec_a.key(): rec_a,
+            rec_b.key(): rec_b,
+        }
+        branch_store.save_index(index, path=self.base_path)
+
+        states = branch_store.load_local_states(username="alice", path=self.base_path)
+        state_map = {(entry["branch_key"], entry["username"]): entry for entry in states}
+        self.assertIn(("g/p/feature/a", "alice"), state_map)
+        self.assertIn(("g/p/feature/b", "alice"), state_map)
+        self.assertEqual(state_map[("g/p/feature/a", "alice")]["state"], "present")
+        self.assertEqual(state_map[("g/p/feature/b", "alice")]["state"], "absent")
 
     def test_upsert_card_adds_version_prefix(self) -> None:
         now = int(time.time())

--- a/buildtool/views/activity_log_view.py
+++ b/buildtool/views/activity_log_view.py
@@ -18,7 +18,7 @@ from PySide6.QtWidgets import (
     QWidget,
 )
 
-from ..core.branch_store import load_nas_activity_log
+from ..core.branch_store import load_activity_log
 from ..ui.widgets import combo_with_arrow
 from .shared_filters import (
     iter_filtered_records,
@@ -27,8 +27,8 @@ from .shared_filters import (
 )
 
 
-class NasActivityLogView(QWidget):
-    """Visualiza el registro de actividad NAS persistido en SQLite."""
+class ActivityLogView(QWidget):
+    """Visualiza el registro de actividad del backend SQL Server."""
 
     def __init__(self, parent: Optional[QWidget] = None):
         super().__init__(parent)
@@ -92,7 +92,7 @@ class NasActivityLogView(QWidget):
     # ----- data -----
     @Slot()
     def _load_entries(self) -> None:
-        self._entries = load_nas_activity_log()
+        self._entries = load_activity_log()
         self._entries.sort(key=lambda e: e.get("ts") or 0, reverse=True)
         sync_group_project_filters(
             self.cboGroup,

--- a/buildtool/views/sprint_view.py
+++ b/buildtool/views/sprint_view.py
@@ -414,7 +414,7 @@ class SprintView(QWidget):
         if sprint and branch_ready:
             branch_record = self._branch_record_for_name(sprint, branch_name)
         branch_exists = bool(
-            branch_record and (branch_record.exists_local or branch_record.exists_origin)
+            branch_record and (branch_record.has_local_copy() or branch_record.exists_origin)
         )
         sprint_closed = bool(sprint and sprint.status == "closed")
         allow_branch_create = (
@@ -540,7 +540,7 @@ class SprintView(QWidget):
         record = self._branch_record_for_card(card, sprint)
         has_branch = bool((card.branch or "").strip())
         if record:
-            local_text = "Sí" if record.exists_local else "No"
+            local_text = "Sí" if record.has_local_copy() else "No"
             origin_text = "Sí" if record.exists_origin else "No"
             creator = card.branch_created_by or record.last_updated_by or record.created_by or ""
         else:
@@ -811,7 +811,7 @@ class SprintView(QWidget):
         self.lblCardChecks.setText(" | ".join(checks))
         record = self._branch_record_for_card(card, sprint)
         if record:
-            self.lblCardLocal.setText("Local: Sí" if record.exists_local else "Local: No")
+            self.lblCardLocal.setText("Local: Sí" if record.has_local_copy() else "Local: No")
             self.lblCardOrigin.setText("Origen: Sí" if record.exists_origin else "Origen: No")
         else:
             self.lblCardLocal.setText("Local: -")
@@ -1300,7 +1300,7 @@ class SprintView(QWidget):
             )
             return
         existing_record = self._branch_record_for_name(sprint, branch_name)
-        if existing_record and (existing_record.exists_local or existing_record.exists_origin):
+        if existing_record and (existing_record.has_local_copy() or existing_record.exists_origin):
             QMessageBox.information(
                 self,
                 "Tarjeta",


### PR DESCRIPTION
## Summary
- replace the NAS-specific history widgets in GitView with the unified BranchHistoryView and a renamed ActivityLogView backed by SQL Server
- add per-user branch locality tracking via the new branch_local_users table and BranchRecord helpers, synchronising state on load/save/upsert
- update sprint, branch history views, and tests to consume the per-user local status and cover the new persistence flow

## Testing
- python -m pytest buildtool/tests/test_branch_store.py

------
https://chatgpt.com/codex/tasks/task_e_68d61023b354832c919ff5451a23eec1